### PR TITLE
Support declaration:true in tsconfig.json and emit declaration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,12 @@ Plugin takes following options:
 
 * `rollupCommonJSResolveHack`: false
 
-	On windows typescript resolver favors POSIX path, while commonjs plugin (and maybe others?) uses native path as module id. This can result in `namedExports` being ignored if rollup happened to use typescript's resolution. Set to true to pass resolved module path through `resolve()` to match up with `rollup-plugin-commonjs`. 
+	On windows typescript resolver favors POSIX path, while commonjs plugin (and maybe others?) uses native path as module id. This can result in `namedExports` being ignored if rollup happened to use typescript's resolution. Set to true to pass resolved module path through `resolve()` to match up with `rollup-plugin-commonjs`.
+
+### Declarations
+
+This plugin respects `declaration: true` in your `tsconfig.json` file. When set, it will emit `*.d.ts` files for your bundle. The resulting file(s) can then be used with the `types`
+property in your `package.json` file as described [here](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).
 
 ### Watch mode
 

--- a/dist/rollup-plugin-typescript2.es.js
+++ b/dist/rollup-plugin-typescript2.es.js
@@ -498,6 +498,7 @@ function typescript(options) {
         return _cache;
     };
     var noErrors = true;
+    var declarations = [];
     // printing compiler option errors
     if (options.check)
         printDiagnostics(context, convertDiagnostic("options", service.getCompilerOptionsDiagnostics()));
@@ -560,9 +561,11 @@ function typescript(options) {
                 }
                 var transpiled = find(output.outputFiles, function (entry) { return endsWith(entry.name, ".js"); });
                 var map$$1 = find(output.outputFiles, function (entry) { return endsWith(entry.name, ".map"); });
+                var dts = find(output.outputFiles, function (entry) { return endsWith(entry.name, ".d.ts"); });
                 return {
                     code: transpiled ? transpiled.text : undefined,
                     map: map$$1 ? JSON.parse(map$$1.text) : { mappings: "" },
+                    dts: dts,
                 };
             });
             if (options.check) {
@@ -574,6 +577,9 @@ function typescript(options) {
                 if (diagnostics.length > 0)
                     noErrors = false;
                 printDiagnostics(contextWrapper, diagnostics);
+            }
+            if (result && result.dts) {
+                declarations.push(result.dts);
             }
             return result;
         },
@@ -595,6 +601,12 @@ function typescript(options) {
                 context.info(yellow("there were errors or warnings above."));
             cache().done();
             round++;
+        },
+        onwrite: function () {
+            declarations.forEach(function (_a) {
+                var name = _a.name, text = _a.text, writeByteOrderMark = _a.writeByteOrderMark;
+                sys.writeFile(name, text, writeByteOrderMark);
+            });
         },
     };
 }

--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -12,6 +12,7 @@ export interface ICode
 {
 	code: string | undefined;
 	map: string | undefined;
+	dts?: ts.OutputFile | undefined;
 }
 
 interface INodeLabel


### PR DESCRIPTION
This PR modifies the plugin to respect `declaration: true` in the `tsconfig.json` file.

When enabled, this plugin will collect the generated `*.d.ts` files from the typescript compilation, and write them out after the bundle has been written.

These files will be written out to the same folder as the destination bundle (possibly make this a configurable folder?)