### PR TITLE
Make declarations share directory root with generated bundle(s)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /typings
 /.rpt2_cache
 /.vscode
+/.idea

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-	"editor.tabSize": 4,
-	"editor.useTabStops": true,
-	"editor.dragAndDrop": true
-}

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ The following compiler options are forced though:
 * `noEmitHelpers`: true
 * `importHelpers`: true
 * `noResolve`: false
-* `outDir`: `process.cwd()`
+* `outDir`: `process.cwd()`,
+* (`declarationDir`: `process.cwd()`) (*only if `useTsconfigDeclarationDir is false in the plugin options*)
 
 You will need to set `"moduleResolution": "node"` in `tsconfig.json` if typescript complains about missing `tslib`. See [#12](https://github.com/ezolenko/rollup-plugin-typescript2/issues/12) and [#14](https://github.com/ezolenko/rollup-plugin-typescript2/issues/14).
 
@@ -89,10 +90,15 @@ Plugin takes following options:
 * `rollupCommonJSResolveHack`: false
 
 	On windows typescript resolver favors POSIX path, while commonjs plugin (and maybe others?) uses native path as module id. This can result in `namedExports` being ignored if rollup happened to use typescript's resolution. Set to true to pass resolved module path through `resolve()` to match up with `rollup-plugin-commonjs`.
+	
+* `useTsconfigDeclarationDir`: false
+
+	If true, declaration files will be emitted in the directory given in the tsconfig. If false, the declaration files will be placed inside the destination directory given in the Rollup configuration.
 
 ### Declarations
 
 This plugin respects `declaration: true` in your `tsconfig.json` file. When set, it will emit `*.d.ts` files for your bundle. The resulting file(s) can then be used with the `types` property in your `package.json` file as described [here](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).
+By default, the declaration files will be located in the same directory as the generated Rollup bundle. If you want to override this behavior and instead use the declarationDir
 
 ### Watch mode
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The following compiler options are forced though:
 * `noEmitHelpers`: true
 * `importHelpers`: true
 * `noResolve`: false
+* `outDir`: `process.cwd()`
 
 You will need to set `"moduleResolution": "node"` in `tsconfig.json` if typescript complains about missing `tslib`. See [#12](https://github.com/ezolenko/rollup-plugin-typescript2/issues/12) and [#14](https://github.com/ezolenko/rollup-plugin-typescript2/issues/14).
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The following compiler options are forced though:
 * `importHelpers`: true
 * `noResolve`: false
 * `outDir`: `process.cwd()`,
-* (`declarationDir`: `process.cwd()`) (*only if `useTsconfigDeclarationDir is false in the plugin options*)
+* (`declarationDir`: `process.cwd()`) (*only if `useTsconfigDeclarationDir` is false in the plugin options*)
 
 You will need to set `"moduleResolution": "node"` in `tsconfig.json` if typescript complains about missing `tslib`. See [#12](https://github.com/ezolenko/rollup-plugin-typescript2/issues/12) and [#14](https://github.com/ezolenko/rollup-plugin-typescript2/issues/14).
 
@@ -98,7 +98,7 @@ Plugin takes following options:
 ### Declarations
 
 This plugin respects `declaration: true` in your `tsconfig.json` file. When set, it will emit `*.d.ts` files for your bundle. The resulting file(s) can then be used with the `types` property in your `package.json` file as described [here](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).
-By default, the declaration files will be located in the same directory as the generated Rollup bundle. If you want to override this behavior and instead use the declarationDir
+By default, the declaration files will be located in the same directory as the generated Rollup bundle. If you want to override this behavior and instead use the declarationDir set `useTsconfigDeclarationDir` to `true` in the plugin options.
 
 ### Watch mode
 

--- a/dist/get-options-overrides.d.ts
+++ b/dist/get-options-overrides.d.ts
@@ -1,2 +1,3 @@
 import { CompilerOptions } from "typescript";
-export declare function getOptionsOverrides(): CompilerOptions;
+import { IOptions } from "./ioptions";
+export declare function getOptionsOverrides({useTsconfigDeclarationDir}: IOptions): CompilerOptions;

--- a/dist/get-options-overrides.d.ts
+++ b/dist/get-options-overrides.d.ts
@@ -1,0 +1,2 @@
+import { CompilerOptions } from "typescript";
+export declare function getOptionsOverrides(): CompilerOptions;

--- a/dist/host.d.ts
+++ b/dist/host.d.ts
@@ -1,18 +1,18 @@
-import * as ts from "typescript";
-export declare class LanguageServiceHost implements ts.LanguageServiceHost {
+import { LanguageServiceHost as TypescriptLanguageServiceHost, IScriptSnapshot, ParsedCommandLine, CompilerOptions } from "typescript";
+export declare class LanguageServiceHost implements TypescriptLanguageServiceHost {
     private parsedConfig;
     private cwd;
     private snapshots;
     private versions;
-    constructor(parsedConfig: ts.ParsedCommandLine);
+    constructor(parsedConfig: ParsedCommandLine);
     reset(): void;
-    setSnapshot(fileName: string, data: string): ts.IScriptSnapshot;
-    getScriptSnapshot(fileName: string): ts.IScriptSnapshot | undefined;
+    setSnapshot(fileName: string, data: string): IScriptSnapshot;
+    getScriptSnapshot(fileName: string): IScriptSnapshot | undefined;
     getCurrentDirectory(): string;
     getScriptVersion(fileName: string): string;
     getScriptFileNames(): string[];
-    getCompilationSettings(): ts.CompilerOptions;
-    getDefaultLibFileName(opts: ts.CompilerOptions): string;
+    getCompilationSettings(): CompilerOptions;
+    getDefaultLibFileName(opts: CompilerOptions): string;
     useCaseSensitiveFileNames(): boolean;
     readDirectory(path: string, extensions?: string[], exclude?: string[], include?: string[]): string[];
     readFile(path: string, encoding?: string): string;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,19 +1,10 @@
 import { IRollupContext } from "./context";
 import { ICode } from "./tscache";
 import { IRollupOptions } from "./irollup-options";
-export interface IOptions {
-    include?: string;
-    exclude?: string;
-    check?: boolean;
-    verbosity?: number;
-    clean?: boolean;
-    cacheRoot?: string;
-    abortOnError?: boolean;
-    rollupCommonJSResolveHack?: boolean;
-    tsconfig?: string;
-}
-export default function typescript(options?: IOptions): {
-    options(config: any): void;
+import { IOptions } from "./ioptions";
+import { Partial } from "./partial";
+export default function typescript(options?: Partial<IOptions>): {
+    options(config: IRollupOptions): void;
     resolveId(importee: string, importer: string): string | null;
     load(id: string): string | undefined;
     transform(this: IRollupContext, code: string, id: string): ICode | undefined;

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,5 +1,6 @@
 import { IRollupContext } from "./context";
 import { ICode } from "./tscache";
+import { IRollupOptions } from "./irollup-options";
 export interface IOptions {
     include?: string;
     exclude?: string;
@@ -17,5 +18,5 @@ export default function typescript(options?: IOptions): {
     load(id: string): string | undefined;
     transform(this: IRollupContext, code: string, id: string): ICode | undefined;
     ongenerate(bundleOptions: any): void;
-    onwrite(): void;
+    onwrite({dest}: IRollupOptions): void;
 };

--- a/dist/parse-ts-config.d.ts
+++ b/dist/parse-ts-config.d.ts
@@ -1,0 +1,3 @@
+import { ParsedCommandLine } from "typescript";
+import { IContext } from "./context";
+export declare function parseTsConfig(tsconfig: string, context: IContext): ParsedCommandLine;

--- a/dist/parse-ts-config.d.ts
+++ b/dist/parse-ts-config.d.ts
@@ -1,3 +1,4 @@
 import { ParsedCommandLine } from "typescript";
 import { IContext } from "./context";
-export declare function parseTsConfig(tsconfig: string, context: IContext): ParsedCommandLine;
+import { IOptions } from "./ioptions";
+export declare function parseTsConfig(tsconfig: string, context: IContext, pluginOptions: IOptions): ParsedCommandLine;

--- a/dist/print-diagnostics.d.ts
+++ b/dist/print-diagnostics.d.ts
@@ -1,0 +1,3 @@
+import { IContext } from "./context";
+import { IDiagnostics } from "./tscache";
+export declare function printDiagnostics(context: IContext, diagnostics: IDiagnostics[]): void;

--- a/dist/rollup-plugin-typescript2.cjs.js
+++ b/dist/rollup-plugin-typescript2.cjs.js
@@ -1,14 +1,15 @@
 /* eslint-disable */
 'use strict';
 
-var _ = require('lodash');
-var fs = require('fs-extra');
-var ts = require('typescript');
-var graph = require('graphlib');
-var hash = require('object-hash');
-var colors = require('colors/safe');
-var path = require('path');
+var lodash = require('lodash');
+var typescript = require('typescript');
+var fs = require('fs');
+var graphlib = require('graphlib');
+var objectHash = require('object-hash');
+var fsExtra = require('fs-extra');
+var colors_safe = require('colors/safe');
 var resolve = require('resolve');
+var path = require('path');
 
 /*! *****************************************************************************
 Copyright (c) Microsoft Corporation. All rights reserved.
@@ -80,7 +81,7 @@ var RollupContext = (function () {
         this.context = context;
         this.prefix = prefix;
         this.hasContext = true;
-        this.hasContext = _.isFunction(this.context.warn) && _.isFunction(this.context.error);
+        this.hasContext = lodash.isFunction(this.context.warn) && lodash.isFunction(this.context.error);
     }
     RollupContext.prototype.warn = function (message) {
         if (this.verbosity < VerbosityLevel.Warning)
@@ -128,17 +129,17 @@ var LanguageServiceHost = (function () {
     };
     LanguageServiceHost.prototype.setSnapshot = function (fileName, data) {
         fileName = this.normalize(fileName);
-        var snapshot = ts.ScriptSnapshot.fromString(data);
+        var snapshot = typescript.ScriptSnapshot.fromString(data);
         this.snapshots[fileName] = snapshot;
         this.versions[fileName] = (this.versions[fileName] || 0) + 1;
         return snapshot;
     };
     LanguageServiceHost.prototype.getScriptSnapshot = function (fileName) {
         fileName = this.normalize(fileName);
-        if (_.has(this.snapshots, fileName))
+        if (lodash.has(this.snapshots, fileName))
             return this.snapshots[fileName];
         if (fs.existsSync(fileName)) {
-            this.snapshots[fileName] = ts.ScriptSnapshot.fromString(ts.sys.readFile(fileName));
+            this.snapshots[fileName] = typescript.ScriptSnapshot.fromString(typescript.sys.readFile(fileName));
             this.versions[fileName] = (this.versions[fileName] || 0) + 1;
             return this.snapshots[fileName];
         }
@@ -158,30 +159,28 @@ var LanguageServiceHost = (function () {
         return this.parsedConfig.options;
     };
     LanguageServiceHost.prototype.getDefaultLibFileName = function (opts) {
-        return ts.getDefaultLibFilePath(opts);
+        return typescript.getDefaultLibFilePath(opts);
     };
     LanguageServiceHost.prototype.useCaseSensitiveFileNames = function () {
-        return ts.sys.useCaseSensitiveFileNames;
+        return typescript.sys.useCaseSensitiveFileNames;
     };
     LanguageServiceHost.prototype.readDirectory = function (path$$1, extensions, exclude, include) {
-        return ts.sys.readDirectory(path$$1, extensions, exclude, include);
+        return typescript.sys.readDirectory(path$$1, extensions, exclude, include);
     };
     LanguageServiceHost.prototype.readFile = function (path$$1, encoding) {
-        return ts.sys.readFile(path$$1, encoding);
+        return typescript.sys.readFile(path$$1, encoding);
     };
     LanguageServiceHost.prototype.fileExists = function (path$$1) {
-        return ts.sys.fileExists(path$$1);
+        return typescript.sys.fileExists(path$$1);
     };
     LanguageServiceHost.prototype.getTypeRootsVersion = function () {
         return 0;
     };
-    // public resolveModuleNames(moduleNames: string[], containingFile: string): ts.ResolvedModule[]
-    // public resolveTypeReferenceDirectives?(typeDirectiveNames: string[], containingFile: string): ResolvedTypeReferenceDirective[]
     LanguageServiceHost.prototype.directoryExists = function (directoryName) {
-        return ts.sys.directoryExists(directoryName);
+        return typescript.sys.directoryExists(directoryName);
     };
     LanguageServiceHost.prototype.getDirectories = function (directoryName) {
-        return ts.sys.getDirectories(directoryName);
+        return typescript.sys.getDirectories(directoryName);
     };
     LanguageServiceHost.prototype.normalize = function (fileName) {
         return fileName.split("\\").join("/");
@@ -204,7 +203,7 @@ var RollingCache = (function () {
         this.rolled = false;
         this.oldCacheRoot = this.cacheRoot + "/cache";
         this.newCacheRoot = this.cacheRoot + "/cache_";
-        fs.emptyDirSync(this.newCacheRoot);
+        fsExtra.emptyDirSync(this.newCacheRoot);
     }
     /**
      * @returns true if name exist in old cache (or either old of new cache if checkNewCache is true)
@@ -227,27 +226,27 @@ var RollingCache = (function () {
             return false;
         if (!fs.existsSync(this.oldCacheRoot))
             return names.length === 0; // empty folder matches
-        return _.isEqual(fs.readdirSync(this.oldCacheRoot).sort(), names.sort());
+        return lodash.isEqual(fs.readdirSync(this.oldCacheRoot).sort(), names.sort());
     };
     /**
      * @returns data for name, must exist in old cache (or either old of new cache if checkNewCache is true)
      */
     RollingCache.prototype.read = function (name) {
         if (this.checkNewCache && fs.existsSync(this.newCacheRoot + "/" + name))
-            return fs.readJsonSync(this.newCacheRoot + "/" + name, { encoding: "utf8" });
-        return fs.readJsonSync(this.oldCacheRoot + "/" + name, { encoding: "utf8" });
+            return fsExtra.readJsonSync(this.newCacheRoot + "/" + name, { encoding: "utf8" });
+        return fsExtra.readJsonSync(this.oldCacheRoot + "/" + name, { encoding: "utf8" });
     };
     RollingCache.prototype.write = function (name, data) {
         if (this.rolled)
             return;
         if (data === undefined)
             return;
-        fs.writeJsonSync(this.newCacheRoot + "/" + name, data);
+        fsExtra.writeJsonSync(this.newCacheRoot + "/" + name, data);
     };
     RollingCache.prototype.touch = function (name) {
         if (this.rolled)
             return;
-        fs.ensureFileSync(this.newCacheRoot + "/" + name);
+        fsExtra.ensureFileSync(this.newCacheRoot + "/" + name);
     };
     /**
      * clears old cache and moves new in its place
@@ -256,16 +255,16 @@ var RollingCache = (function () {
         if (this.rolled)
             return;
         this.rolled = true;
-        fs.removeSync(this.oldCacheRoot);
+        fsExtra.removeSync(this.oldCacheRoot);
         fs.renameSync(this.newCacheRoot, this.oldCacheRoot);
     };
     return RollingCache;
 }());
 
 function convertDiagnostic(type, data) {
-    return _.map(data, function (diagnostic) {
+    return lodash.map(data, function (diagnostic) {
         var entry = {
-            flatMessage: ts.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
+            flatMessage: typescript.flattenDiagnosticMessageText(diagnostic.messageText, "\n"),
             category: diagnostic.category,
             code: diagnostic.code,
             type: type,
@@ -286,46 +285,46 @@ var TsCache = (function () {
         this.context = context;
         this.cacheVersion = "6";
         this.ambientTypesDirty = false;
-        this.cacheDir = cache + "/" + hash.sha1({
+        this.cacheDir = cache + "/" + objectHash.sha1({
             version: this.cacheVersion,
             rootFilenames: rootFilenames,
             options: this.options,
             rollupConfig: this.rollupConfig,
-            tsVersion: ts.version,
+            tsVersion: typescript.version,
         });
-        this.dependencyTree = new graph.Graph({ directed: true });
+        this.dependencyTree = new graphlib.Graph({ directed: true });
         this.dependencyTree.setDefaultNodeLabel(function (_node) { return ({ dirty: false }); });
-        var automaticTypes = _.map(ts.getAutomaticTypeDirectiveNames(options, ts.sys), function (entry) { return ts.resolveTypeReferenceDirective(entry, undefined, options, ts.sys); })
+        var automaticTypes = lodash.map(typescript.getAutomaticTypeDirectiveNames(options, typescript.sys), function (entry) { return typescript.resolveTypeReferenceDirective(entry, undefined, options, typescript.sys); })
             .filter(function (entry) { return entry.resolvedTypeReferenceDirective && entry.resolvedTypeReferenceDirective.resolvedFileName; })
             .map(function (entry) { return entry.resolvedTypeReferenceDirective.resolvedFileName; });
-        this.ambientTypes = _.filter(rootFilenames, function (file) { return _.endsWith(file, ".d.ts"); })
+        this.ambientTypes = lodash.filter(rootFilenames, function (file) { return lodash.endsWith(file, ".d.ts"); })
             .concat(automaticTypes)
             .map(function (id) { return ({ id: id, snapshot: _this.host.getScriptSnapshot(id) }); });
         this.init();
         this.checkAmbientTypes();
     }
     TsCache.prototype.clean = function () {
-        this.context.info(colors.blue("cleaning cache: " + this.cacheDir));
-        fs.emptyDirSync(this.cacheDir);
+        this.context.info(colors_safe.blue("cleaning cache: " + this.cacheDir));
+        fsExtra.emptyDirSync(this.cacheDir);
         this.init();
     };
     TsCache.prototype.setDependency = function (importee, importer) {
         // importee -> importer
-        this.context.debug(colors.blue("dependency") + " '" + importee + "'");
+        this.context.debug(colors_safe.blue("dependency") + " '" + importee + "'");
         this.context.debug("    imported by '" + importer + "'");
         this.dependencyTree.setEdge(importer, importee);
     };
     TsCache.prototype.walkTree = function (cb) {
-        var acyclic = graph.alg.isAcyclic(this.dependencyTree);
+        var acyclic = graphlib.alg.isAcyclic(this.dependencyTree);
         if (acyclic) {
-            _.each(graph.alg.topsort(this.dependencyTree), function (id) { return cb(id); });
+            lodash.each(graphlib.alg.topsort(this.dependencyTree), function (id) { return cb(id); });
             return;
         }
-        this.context.info(colors.yellow("import tree has cycles"));
-        _.each(this.dependencyTree.nodes(), function (id) { return cb(id); });
+        this.context.info(colors_safe.yellow("import tree has cycles"));
+        lodash.each(this.dependencyTree.nodes(), function (id) { return cb(id); });
     };
     TsCache.prototype.done = function () {
-        this.context.info(colors.blue("rolling caches"));
+        this.context.info(colors_safe.blue("rolling caches"));
         this.codeCache.roll();
         this.semanticDiagnosticsCache.roll();
         this.syntacticDiagnosticsCache.roll();
@@ -333,16 +332,16 @@ var TsCache = (function () {
     };
     TsCache.prototype.getCompiled = function (id, snapshot, transform) {
         var name = this.makeName(id, snapshot);
-        this.context.info(colors.blue("transpiling") + " '" + id + "'");
+        this.context.info(colors_safe.blue("transpiling") + " '" + id + "'");
         this.context.debug("    cache: '" + this.codeCache.path(name) + "'");
-        if (!this.codeCache.exists(name) || this.isDirty(id, snapshot, false)) {
-            this.context.debug(colors.yellow("    cache miss"));
+        if (!this.codeCache.exists(name) || this.isDirty(id, false)) {
+            this.context.debug(colors_safe.yellow("    cache miss"));
             var transformedData = transform();
             this.codeCache.write(name, transformedData);
-            this.markAsDirty(id, snapshot);
+            this.markAsDirty(id);
             return transformedData;
         }
-        this.context.debug(colors.green("    cache hit"));
+        this.context.debug(colors_safe.green("    cache hit"));
         var data = this.codeCache.read(name);
         this.codeCache.write(name, data);
         return data;
@@ -355,8 +354,8 @@ var TsCache = (function () {
     };
     TsCache.prototype.checkAmbientTypes = function () {
         var _this = this;
-        this.context.debug(colors.blue("Ambient types:"));
-        var typeNames = _.filter(this.ambientTypes, function (snapshot) { return snapshot.snapshot !== undefined; })
+        this.context.debug(colors_safe.blue("Ambient types:"));
+        var typeNames = lodash.filter(this.ambientTypes, function (snapshot) { return snapshot.snapshot !== undefined; })
             .map(function (snapshot) {
             _this.context.debug("    " + snapshot.id);
             return _this.makeName(snapshot.id, snapshot.snapshot);
@@ -364,20 +363,20 @@ var TsCache = (function () {
         // types dirty if any d.ts changed, added or removed
         this.ambientTypesDirty = !this.typesCache.match(typeNames);
         if (this.ambientTypesDirty)
-            this.context.info(colors.yellow("ambient types changed, redoing all semantic diagnostics"));
-        _.each(typeNames, function (name) { return _this.typesCache.touch(name); });
+            this.context.info(colors_safe.yellow("ambient types changed, redoing all semantic diagnostics"));
+        lodash.each(typeNames, function (name) { return _this.typesCache.touch(name); });
     };
     TsCache.prototype.getDiagnostics = function (type, cache, id, snapshot, check) {
         var name = this.makeName(id, snapshot);
         this.context.debug("    cache: '" + cache.path(name) + "'");
-        if (!cache.exists(name) || this.isDirty(id, snapshot, true)) {
-            this.context.debug(colors.yellow("    cache miss"));
-            var data_1 = convertDiagnostic(type, check());
-            cache.write(name, data_1);
-            this.markAsDirty(id, snapshot);
-            return data_1;
+        if (!cache.exists(name) || this.isDirty(id, true)) {
+            this.context.debug(colors_safe.yellow("    cache miss"));
+            var convertedData = convertDiagnostic(type, check());
+            cache.write(name, convertedData);
+            this.markAsDirty(id);
+            return convertedData;
         }
-        this.context.debug(colors.green("    cache hit"));
+        this.context.debug(colors_safe.green("    cache hit"));
         var data = cache.read(name);
         cache.write(name, data);
         return data;
@@ -388,11 +387,11 @@ var TsCache = (function () {
         this.syntacticDiagnosticsCache = new RollingCache(this.cacheDir + "/syntacticDiagnostics", true);
         this.semanticDiagnosticsCache = new RollingCache(this.cacheDir + "/semanticDiagnostics", true);
     };
-    TsCache.prototype.markAsDirty = function (id, _snapshot) {
+    TsCache.prototype.markAsDirty = function (id) {
         this.dependencyTree.setNode(id, { dirty: true });
     };
     // returns true if node or any of its imports or any of global types changed
-    TsCache.prototype.isDirty = function (id, _snapshot, checkImports) {
+    TsCache.prototype.isDirty = function (id, checkImports) {
         var _this = this;
         var label = this.dependencyTree.node(id);
         if (!label)
@@ -401,8 +400,8 @@ var TsCache = (function () {
             return label.dirty;
         if (this.ambientTypesDirty)
             return true;
-        var dependencies = graph.alg.dijkstra(this.dependencyTree, id);
-        return _.some(dependencies, function (dependency, node) {
+        var dependencies = graphlib.alg.dijkstra(this.dependencyTree, id);
+        return lodash.some(dependencies, function (dependency, node) {
             if (!node || dependency.distance === Infinity)
                 return false;
             var l = _this.dependencyTree.node(node);
@@ -414,21 +413,65 @@ var TsCache = (function () {
     };
     TsCache.prototype.makeName = function (id, snapshot) {
         var data = snapshot.getText(0, snapshot.getLength());
-        return hash.sha1({ data: data, id: id });
+        return objectHash.sha1({ data: data, id: id });
     };
     return TsCache;
 }());
 
-// tslint:disable-next-line:no-var-requires
-var createFilter = require("rollup-pluginutils").createFilter;
+function printDiagnostics(context, diagnostics) {
+    lodash.each(diagnostics, function (diagnostic) {
+        var print;
+        var color;
+        var category;
+        switch (diagnostic.category) {
+            case typescript.DiagnosticCategory.Message:
+                print = context.info;
+                color = colors_safe.white;
+                category = "";
+                break;
+            case typescript.DiagnosticCategory.Error:
+                print = context.error;
+                color = colors_safe.red;
+                category = "error";
+                break;
+            case typescript.DiagnosticCategory.Warning:
+            default:
+                print = context.warn;
+                color = colors_safe.yellow;
+                category = "warning";
+                break;
+        }
+        var type = diagnostic.type + " ";
+        if (diagnostic.fileLine)
+            print.call(context, [diagnostic.fileLine + ": " + type + category + " TS" + diagnostic.code + " " + color(diagnostic.flatMessage)]);
+        else
+            print.call(context, ["" + type + category + " TS" + diagnostic.code + " " + color(diagnostic.flatMessage)]);
+    });
+}
+
 function getOptionsOverrides() {
     return {
-        module: ts.ModuleKind.ES2015,
+        module: typescript.ModuleKind.ES2015,
         noEmitHelpers: true,
         importHelpers: true,
         noResolve: false,
+        outDir: process.cwd(),
     };
 }
+
+function parseTsConfig(tsconfig, context) {
+    var fileName = typescript.findConfigFile(process.cwd(), typescript.sys.fileExists, tsconfig);
+    if (!fileName)
+        throw new Error("couldn't find '" + tsconfig + "' in " + process.cwd());
+    var text = typescript.sys.readFile(fileName);
+    var result = typescript.parseConfigFileTextToJson(fileName, text);
+    if (result.error) {
+        printDiagnostics(context, convertDiagnostic("config", [result.error]));
+        throw new Error("failed to parse " + fileName);
+    }
+    return typescript.parseJsonConfigFileContent(result.config, typescript.sys, path.dirname(fileName), getOptionsOverrides(), fileName);
+}
+
 // The injected id for helpers.
 var TSLIB = "tslib";
 var tslibSource;
@@ -441,53 +484,30 @@ catch (e) {
     console.warn("Error loading `tslib` helper library.");
     throw e;
 }
-function parseTsConfig(tsconfig, context) {
-    var fileName = ts.findConfigFile(process.cwd(), ts.sys.fileExists, tsconfig);
-    if (!fileName)
-        throw new Error("couldn't find '" + tsconfig + "' in " + process.cwd());
-    var text = ts.sys.readFile(fileName);
-    var result = ts.parseConfigFileTextToJson(fileName, text);
-    if (result.error) {
-        printDiagnostics(context, convertDiagnostic("config", [result.error]));
-        throw new Error("failed to parse " + fileName);
-    }
-    var configParseResult = ts.parseJsonConfigFileContent(result.config, ts.sys, path.dirname(fileName), getOptionsOverrides(), fileName);
-    return configParseResult;
-}
-function printDiagnostics(context, diagnostics) {
-    _.each(diagnostics, function (diagnostic) {
-        var print;
-        var color;
-        var category;
-        switch (diagnostic.category) {
-            case ts.DiagnosticCategory.Message:
-                print = context.info;
-                color = colors.white;
-                category = "";
-                break;
-            case ts.DiagnosticCategory.Error:
-                print = context.error;
-                color = colors.red;
-                category = "error";
-                break;
-            case ts.DiagnosticCategory.Warning:
-            default:
-                print = context.warn;
-                color = colors.yellow;
-                category = "warning";
-                break;
-        }
-        // const type = "";
-        var type = diagnostic.type + " ";
-        if (diagnostic.fileLine)
-            print.call(context, [diagnostic.fileLine + ": " + type + category + " TS" + diagnostic.code + " " + color(diagnostic.flatMessage)]);
-        else
-            print.call(context, ["" + type + category + " TS" + diagnostic.code + " " + color(diagnostic.flatMessage)]);
-    });
-}
-function typescript(options) {
-    options = __assign({}, options);
-    _.defaults(options, {
+
+// tslint:disable-next-line:no-var-requires
+var createFilter = require("rollup-pluginutils").createFilter;
+var watchMode = false;
+var round = 0;
+var targetCount = 0;
+var rollupOptions;
+var pluginOptions;
+var context;
+var filter$1;
+var parsedConfig;
+var servicesHost;
+var service;
+var _cache;
+var noErrors = true;
+var declarations = {};
+var cache = function () {
+    if (!_cache)
+        _cache = new TsCache(servicesHost, pluginOptions.cacheRoot, parsedConfig.options, rollupOptions, parsedConfig.fileNames, context);
+    return _cache;
+};
+function typescript$1(options) {
+    pluginOptions = __assign({}, options);
+    lodash.defaults(pluginOptions, {
         check: true,
         verbosity: VerbosityLevel.Warning,
         clean: false,
@@ -498,33 +518,21 @@ function typescript(options) {
         rollupCommonJSResolveHack: false,
         tsconfig: "tsconfig.json",
     });
-    var rollupConfig;
-    var watchMode = false;
-    var round = 0;
-    var targetCount = 0;
-    var context = new ConsoleContext(options.verbosity, "rpt2: ");
-    context.info("Typescript version: " + ts.version);
-    context.debug("Options: " + JSON.stringify(options, undefined, 4));
-    var filter$$1 = createFilter(options.include, options.exclude);
-    var parsedConfig = parseTsConfig(options.tsconfig, context);
-    var servicesHost = new LanguageServiceHost(parsedConfig);
-    var service = ts.createLanguageService(servicesHost, ts.createDocumentRegistry());
-    var _cache;
-    var cache = function () {
-        if (!_cache)
-            _cache = new TsCache(servicesHost, options.cacheRoot, parsedConfig.options, rollupConfig, parsedConfig.fileNames, context);
-        return _cache;
-    };
-    var noErrors = true;
-    var declarations = {};
-    // printing compiler option errors
-    if (options.check)
-        printDiagnostics(context, convertDiagnostic("options", service.getCompilerOptionsDiagnostics()));
     return {
         options: function (config) {
-            rollupConfig = config;
-            context.debug("rollupConfig: " + JSON.stringify(rollupConfig, undefined, 4));
-            if (options.clean)
+            rollupOptions = config;
+            context = new ConsoleContext(pluginOptions.verbosity, "rpt2: ");
+            context.info("Typescript version: " + typescript.version);
+            context.debug("Plugin Options: " + JSON.stringify(pluginOptions, undefined, 4));
+            filter$1 = createFilter(pluginOptions.include, pluginOptions.exclude);
+            parsedConfig = parseTsConfig(pluginOptions.tsconfig, context);
+            servicesHost = new LanguageServiceHost(parsedConfig);
+            service = typescript.createLanguageService(servicesHost, typescript.createDocumentRegistry());
+            // printing compiler option errors
+            if (pluginOptions.check)
+                printDiagnostics(context, convertDiagnostic("options", service.getCompilerOptionsDiagnostics()));
+            context.debug("rollupConfig: " + JSON.stringify(rollupOptions, undefined, 4));
+            if (pluginOptions.clean)
                 cache().clean();
         },
         resolveId: function (importee, importer) {
@@ -534,16 +542,16 @@ function typescript(options) {
                 return null;
             importer = importer.split("\\").join("/");
             // TODO: use module resolution cache
-            var result = ts.nodeModuleNameResolver(importee, importer, parsedConfig.options, ts.sys);
+            var result = typescript.nodeModuleNameResolver(importee, importer, parsedConfig.options, typescript.sys);
             if (result.resolvedModule && result.resolvedModule.resolvedFileName) {
-                if (filter$$1(result.resolvedModule.resolvedFileName))
+                if (filter$1(result.resolvedModule.resolvedFileName))
                     cache().setDependency(result.resolvedModule.resolvedFileName, importer);
-                if (_.endsWith(result.resolvedModule.resolvedFileName, ".d.ts"))
+                if (lodash.endsWith(result.resolvedModule.resolvedFileName, ".d.ts"))
                     return null;
-                var resolved = options.rollupCommonJSResolveHack
+                var resolved = pluginOptions.rollupCommonJSResolveHack
                     ? resolve.sync(result.resolvedModule.resolvedFileName)
                     : result.resolvedModule.resolvedFileName;
-                context.debug(colors.blue("resolving") + " '" + importee + "'");
+                context.debug(colors_safe.blue("resolving") + " '" + importee + "'");
                 context.debug("    to '" + resolved + "'");
                 return resolved;
             }
@@ -556,9 +564,9 @@ function typescript(options) {
         },
         transform: function (code, id) {
             var _this = this;
-            if (!filter$$1(id))
+            if (!filter$1(id))
                 return undefined;
-            var contextWrapper = new RollupContext(options.verbosity, options.abortOnError, this, "rpt2: ");
+            var contextWrapper = new RollupContext(pluginOptions.verbosity, pluginOptions.abortOnError, this, "rpt2: ");
             var snapshot = servicesHost.setSnapshot(id, code);
             // getting compiled file from cache or from ts
             var result = cache().getCompiled(id, snapshot, function () {
@@ -566,7 +574,7 @@ function typescript(options) {
                 if (output.emitSkipped) {
                     noErrors = false;
                     // always checking on fatal errors, even if options.check is set to false
-                    var diagnostics = _.concat(cache().getSyntacticDiagnostics(id, snapshot, function () {
+                    var diagnostics = lodash.concat(cache().getSyntacticDiagnostics(id, snapshot, function () {
                         return service.getSyntacticDiagnostics(id);
                     }), cache().getSemanticDiagnostics(id, snapshot, function () {
                         return service.getSemanticDiagnostics(id);
@@ -574,20 +582,20 @@ function typescript(options) {
                     printDiagnostics(contextWrapper, diagnostics);
                     // since no output was generated, aborting compilation
                     cache().done();
-                    if (_.isFunction(_this.error))
-                        _this.error(colors.red("failed to transpile '" + id + "'"));
+                    if (lodash.isFunction(_this.error))
+                        _this.error(colors_safe.red("failed to transpile '" + id + "'"));
                 }
-                var transpiled = _.find(output.outputFiles, function (entry) { return _.endsWith(entry.name, ".js") || _.endsWith(entry.name, ".jsx"); });
-                var map$$1 = _.find(output.outputFiles, function (entry) { return _.endsWith(entry.name, ".map"); });
-                var dts = _.find(output.outputFiles, function (entry) { return _.endsWith(entry.name, ".d.ts"); });
+                var transpiled = lodash.find(output.outputFiles, function (entry) { return lodash.endsWith(entry.name, ".js") || lodash.endsWith(entry.name, ".jsx"); });
+                var map$$1 = lodash.find(output.outputFiles, function (entry) { return lodash.endsWith(entry.name, ".map"); });
+                var dts = lodash.find(output.outputFiles, function (entry) { return lodash.endsWith(entry.name, ".d.ts"); });
                 return {
                     code: transpiled ? transpiled.text : undefined,
                     map: map$$1 ? JSON.parse(map$$1.text) : { mappings: "" },
                     dts: dts,
                 };
             });
-            if (options.check) {
-                var diagnostics = _.concat(cache().getSyntacticDiagnostics(id, snapshot, function () {
+            if (pluginOptions.check) {
+                var diagnostics = lodash.concat(cache().getSyntacticDiagnostics(id, snapshot, function () {
                     return service.getSyntacticDiagnostics(id);
                 }), cache().getSemanticDiagnostics(id, snapshot, function () {
                     return service.getSemanticDiagnostics(id);
@@ -603,7 +611,7 @@ function typescript(options) {
             return result;
         },
         ongenerate: function (bundleOptions) {
-            targetCount = _.get(bundleOptions, "targets.length", 1);
+            targetCount = lodash.get(bundleOptions, "targets.length", 1);
             if (round >= targetCount) {
                 watchMode = true;
                 round = 0;
@@ -612,34 +620,27 @@ function typescript(options) {
             if (watchMode && round === 0) {
                 context.debug("running in watch mode");
                 cache().walkTree(function (id) {
-                    var diagnostics = _.concat(convertDiagnostic("syntax", service.getSyntacticDiagnostics(id)), convertDiagnostic("semantic", service.getSemanticDiagnostics(id)));
+                    var diagnostics = lodash.concat(convertDiagnostic("syntax", service.getSyntacticDiagnostics(id)), convertDiagnostic("semantic", service.getSemanticDiagnostics(id)));
                     printDiagnostics(context, diagnostics);
                 });
             }
             if (!watchMode && !noErrors)
-                context.info(colors.yellow("there were errors or warnings above."));
+                context.info(colors_safe.yellow("there were errors or warnings above."));
             cache().done();
             round++;
         },
         onwrite: function (_a) {
             var dest = _a.dest;
-            // Expect the destination path given in the rollup bundle to be a relative path (if given). Join it with process.cwd()
-            var bundleDirectory = dest == null ? null : path.join(process.cwd(), path.dirname(dest));
-            var bundleName = dest == null ? null : path.basename(dest);
-            var bundleExt = dest == null ? null : path.extname(dest);
-            _.each(declarations, function (_a) {
+            var destDirectory = path.join(process.cwd(), path.dirname(dest));
+            var baseDeclarationDir = parsedConfig.options.outDir;
+            lodash.each(declarations, function (_a) {
                 var name = _a.name, text = _a.text, writeByteOrderMark = _a.writeByteOrderMark;
-                // If no 'dest' is given, the bundle has no directory, name or extension. In that case, use the default declaration path given by Typescript.
-                if (bundleName == null || bundleExt == null || bundleDirectory == null)
-                    return ts.sys.writeFile(name, text, writeByteOrderMark);
-                // Otherwise, try to play nice with the destination from the rollup config.
-                // Make sure that the declaration file has the same name as the bundle (but a different extension)
-                var declarationName = bundleExt === "" ? bundleName + ".d.ts" : bundleName.slice(0, bundleName.indexOf(bundleExt)) + ".d.ts";
-                var declarationFilepath = path.join(bundleDirectory, declarationName);
-                ts.sys.writeFile(declarationFilepath, text, writeByteOrderMark);
+                var relativeFromBaseDeclarationDir = path.relative(baseDeclarationDir, name);
+                var writeToPath = path.join(destDirectory, relativeFromBaseDeclarationDir);
+                typescript.sys.writeFile(writeToPath, text, writeByteOrderMark);
             });
         },
     };
 }
 
-module.exports = typescript;
+module.exports = typescript$1;

--- a/dist/tscache.d.ts
+++ b/dist/tscache.d.ts
@@ -1,18 +1,18 @@
 import { IContext } from "./context";
-import * as ts from "typescript";
+import { Diagnostic, DiagnosticCategory, IScriptSnapshot, OutputFile, LanguageServiceHost, CompilerOptions } from "typescript";
 export interface ICode {
     code: string | undefined;
     map: string | undefined;
-    dts?: ts.OutputFile | undefined;
+    dts?: OutputFile | undefined;
 }
 export interface IDiagnostics {
     flatMessage: string;
     fileLine?: string;
-    category: ts.DiagnosticCategory;
+    category: DiagnosticCategory;
     code: number;
     type: string;
 }
-export declare function convertDiagnostic(type: string, data: ts.Diagnostic[]): IDiagnostics[];
+export declare function convertDiagnostic(type: string, data: Diagnostic[]): IDiagnostics[];
 export declare class TsCache {
     private host;
     private options;
@@ -27,18 +27,18 @@ export declare class TsCache {
     private typesCache;
     private semanticDiagnosticsCache;
     private syntacticDiagnosticsCache;
-    constructor(host: ts.LanguageServiceHost, cache: string, options: ts.CompilerOptions, rollupConfig: any, rootFilenames: string[], context: IContext);
+    constructor(host: LanguageServiceHost, cache: string, options: CompilerOptions, rollupConfig: any, rootFilenames: string[], context: IContext);
     clean(): void;
     setDependency(importee: string, importer: string): void;
     walkTree(cb: (id: string) => void | false): void;
     done(): void;
-    getCompiled(id: string, snapshot: ts.IScriptSnapshot, transform: () => ICode | undefined): ICode | undefined;
-    getSyntacticDiagnostics(id: string, snapshot: ts.IScriptSnapshot, check: () => ts.Diagnostic[]): IDiagnostics[];
-    getSemanticDiagnostics(id: string, snapshot: ts.IScriptSnapshot, check: () => ts.Diagnostic[]): IDiagnostics[];
+    getCompiled(id: string, snapshot: IScriptSnapshot, transform: () => ICode | undefined): ICode | undefined;
+    getSyntacticDiagnostics(id: string, snapshot: IScriptSnapshot, check: () => Diagnostic[]): IDiagnostics[];
+    getSemanticDiagnostics(id: string, snapshot: IScriptSnapshot, check: () => Diagnostic[]): IDiagnostics[];
     private checkAmbientTypes();
     private getDiagnostics(type, cache, id, snapshot, check);
     private init();
-    private markAsDirty(id, _snapshot);
-    private isDirty(id, _snapshot, checkImports);
+    private markAsDirty(id);
+    private isDirty(id, checkImports);
     private makeName(id, snapshot);
 }

--- a/dist/tslib.d.ts
+++ b/dist/tslib.d.ts
@@ -1,0 +1,2 @@
+export declare const TSLIB = "tslib";
+export declare let tslibSource: string;

--- a/src/get-options-overrides.ts
+++ b/src/get-options-overrides.ts
@@ -1,0 +1,11 @@
+import {CompilerOptions, ModuleKind} from "typescript";
+
+export function getOptionsOverrides(): CompilerOptions {
+	return {
+		module: ModuleKind.ES2015,
+		noEmitHelpers: true,
+		importHelpers: true,
+		noResolve: false,
+		outDir: process.cwd(),
+	};
+}

--- a/src/get-options-overrides.ts
+++ b/src/get-options-overrides.ts
@@ -1,11 +1,13 @@
 import {CompilerOptions, ModuleKind} from "typescript";
+import {IOptions} from "./ioptions";
 
-export function getOptionsOverrides(): CompilerOptions {
+export function getOptionsOverrides({useTsconfigDeclarationDir}: IOptions): CompilerOptions {
 	return {
 		module: ModuleKind.ES2015,
 		noEmitHelpers: true,
 		importHelpers: true,
 		noResolve: false,
 		outDir: process.cwd(),
+		...(useTsconfigDeclarationDir ? {} : {declarationDir: process.cwd()}),
 	};
 }

--- a/src/host.ts
+++ b/src/host.ts
@@ -1,14 +1,14 @@
-import * as fs from "fs-extra";
-import * as ts from "typescript";
-import * as _ from "lodash";
+import {LanguageServiceHost as TypescriptLanguageServiceHost, IScriptSnapshot, ParsedCommandLine, ScriptSnapshot, sys, CompilerOptions, getDefaultLibFilePath} from "typescript";
+import {existsSync} from "fs";
+import {has} from "lodash";
 
-export class LanguageServiceHost implements ts.LanguageServiceHost
+export class LanguageServiceHost implements TypescriptLanguageServiceHost
 {
 	private cwd = process.cwd();
-	private snapshots: { [fileName: string]: ts.IScriptSnapshot } = {};
+	private snapshots: { [fileName: string]: IScriptSnapshot } = {};
 	private versions: { [fileName: string]: number } = {};
 
-	constructor(private parsedConfig: ts.ParsedCommandLine)
+	constructor(private parsedConfig: ParsedCommandLine)
 	{
 	}
 
@@ -18,26 +18,26 @@ export class LanguageServiceHost implements ts.LanguageServiceHost
 		this.versions = {};
 	}
 
-	public setSnapshot(fileName: string, data: string): ts.IScriptSnapshot
+	public setSnapshot(fileName: string, data: string): IScriptSnapshot
 	{
 		fileName = this.normalize(fileName);
 
-		const snapshot = ts.ScriptSnapshot.fromString(data);
+		const snapshot = ScriptSnapshot.fromString(data);
 		this.snapshots[fileName] = snapshot;
 		this.versions[fileName] = (this.versions[fileName] || 0) + 1;
 		return snapshot;
 	}
 
-	public getScriptSnapshot(fileName: string): ts.IScriptSnapshot | undefined
+	public getScriptSnapshot(fileName: string): IScriptSnapshot | undefined
 	{
 		fileName = this.normalize(fileName);
 
-		if (_.has(this.snapshots, fileName))
+		if (has(this.snapshots, fileName))
 			return this.snapshots[fileName];
 
-		if (fs.existsSync(fileName))
+		if (existsSync(fileName))
 		{
-			this.snapshots[fileName] = ts.ScriptSnapshot.fromString(ts.sys.readFile(fileName));
+			this.snapshots[fileName] = ScriptSnapshot.fromString(sys.readFile(fileName));
 			this.versions[fileName] = (this.versions[fileName] || 0) + 1;
 			return this.snapshots[fileName];
 		}
@@ -62,34 +62,34 @@ export class LanguageServiceHost implements ts.LanguageServiceHost
 		return this.parsedConfig.fileNames;
 	}
 
-	public getCompilationSettings(): ts.CompilerOptions
+	public getCompilationSettings(): CompilerOptions
 	{
 		return this.parsedConfig.options;
 	}
 
-	public getDefaultLibFileName(opts: ts.CompilerOptions)
+	public getDefaultLibFileName(opts: CompilerOptions)
 	{
-		return ts.getDefaultLibFilePath(opts);
+		return getDefaultLibFilePath(opts);
 	}
 
 	public useCaseSensitiveFileNames(): boolean
 	{
-		return ts.sys.useCaseSensitiveFileNames;
+		return sys.useCaseSensitiveFileNames;
 	}
 
 	public readDirectory(path: string, extensions?: string[], exclude?: string[], include?: string[]): string[]
 	{
-		return ts.sys.readDirectory(path, extensions, exclude, include);
+		return sys.readDirectory(path, extensions, exclude, include);
 	}
 
 	public readFile(path: string, encoding?: string): string
 	{
-		return ts.sys.readFile(path, encoding);
+		return sys.readFile(path, encoding);
 	}
 
 	public fileExists(path: string): boolean
 	{
-		return ts.sys.fileExists(path);
+		return sys.fileExists(path);
 	}
 
 	public getTypeRootsVersion(): number
@@ -97,18 +97,14 @@ export class LanguageServiceHost implements ts.LanguageServiceHost
 		return 0;
 	}
 
-	// public resolveModuleNames(moduleNames: string[], containingFile: string): ts.ResolvedModule[]
-
-	// public resolveTypeReferenceDirectives?(typeDirectiveNames: string[], containingFile: string): ResolvedTypeReferenceDirective[]
-
 	public directoryExists(directoryName: string): boolean
 	{
-		return ts.sys.directoryExists(directoryName);
+		return sys.directoryExists(directoryName);
 	}
 
 	public getDirectories(directoryName: string): string[]
 	{
-		return ts.sys.getDirectories(directoryName);
+		return sys.getDirectories(directoryName);
 	}
 
 	private normalize(fileName: string)

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,8 +11,8 @@ import { Partial } from "./partial";
 import { parseTsConfig } from "./parse-ts-config";
 import { printDiagnostics } from "./print-diagnostics";
 import { TSLIB, tslibSource } from "./tslib";
-import {blue, red, yellow} from "colors/safe";
-import {join, relative, dirname, isAbsolute} from "path";
+import { blue, red, yellow } from "colors/safe";
+import { join, relative, dirname, isAbsolute } from "path";
 
 export default function typescript(options?: Partial<IOptions>)
 {

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {join, relative, dirname} from "path";
 
 // tslint:disable-next-line:no-var-requires
 const createFilter = require("rollup-pluginutils").createFilter;
+// tslint:enable-next-line:no-var-requires
 let watchMode = false;
 let round = 0;
 let targetCount = 0;
@@ -66,7 +67,7 @@ export default function typescript(options?: Partial<IOptions>)
 
 			filter = createFilter(pluginOptions.include, pluginOptions.exclude);
 
-			parsedConfig = parseTsConfig(pluginOptions.tsconfig, context);
+			parsedConfig = parseTsConfig(pluginOptions.tsconfig, context, pluginOptions);
 
 			servicesHost = new LanguageServiceHost(parsedConfig);
 
@@ -240,8 +241,7 @@ export default function typescript(options?: Partial<IOptions>)
 			const baseDeclarationDir = parsedConfig.options.outDir as string;
 			each(declarations, ({ name, text, writeByteOrderMark }) =>
 			{
-				const relativeFromBaseDeclarationDir = relative(baseDeclarationDir, name);
-				const writeToPath = join(destDirectory, relativeFromBaseDeclarationDir);
+				const writeToPath = pluginOptions.useTsconfigDeclarationDir ? name : join(destDirectory, relative(baseDeclarationDir, name));
 				sys.writeFile(writeToPath, text, writeByteOrderMark);
 			});
 		},

--- a/src/ioptions.ts
+++ b/src/ioptions.ts
@@ -1,0 +1,12 @@
+export interface IOptions
+{
+	include: string;
+	exclude: string;
+	check: boolean;
+	verbosity: number;
+	clean: boolean;
+	cacheRoot: string;
+	abortOnError: boolean;
+	rollupCommonJSResolveHack: boolean;
+	tsconfig: string;
+}

--- a/src/ioptions.ts
+++ b/src/ioptions.ts
@@ -9,4 +9,5 @@ export interface IOptions
 	abortOnError: boolean;
 	rollupCommonJSResolveHack: boolean;
 	tsconfig: string;
+	useTsconfigDeclarationDir: boolean;
 }

--- a/src/irollup-options.ts
+++ b/src/irollup-options.ts
@@ -1,0 +1,3 @@
+export interface IRollupOptions {
+	dest?: string;
+}

--- a/src/parse-ts-config.ts
+++ b/src/parse-ts-config.ts
@@ -4,8 +4,9 @@ import {dirname} from "path";
 import {printDiagnostics} from "./print-diagnostics";
 import {convertDiagnostic} from "./tscache";
 import {getOptionsOverrides} from "./get-options-overrides";
+import {IOptions} from "./ioptions";
 
-export function parseTsConfig(tsconfig: string, context: IContext): ParsedCommandLine {
+export function parseTsConfig(tsconfig: string, context: IContext, pluginOptions: IOptions): ParsedCommandLine {
 	const fileName = findConfigFile(process.cwd(), sys.fileExists, tsconfig);
 
 	if (!fileName)
@@ -19,5 +20,5 @@ export function parseTsConfig(tsconfig: string, context: IContext): ParsedComman
 		throw new Error(`failed to parse ${fileName}`);
 	}
 
-	return parseJsonConfigFileContent(result.config, sys, dirname(fileName), getOptionsOverrides(), fileName);
+	return parseJsonConfigFileContent(result.config, sys, dirname(fileName), getOptionsOverrides(pluginOptions), fileName);
 }

--- a/src/parse-ts-config.ts
+++ b/src/parse-ts-config.ts
@@ -1,0 +1,23 @@
+import {findConfigFile, parseConfigFileTextToJson, ParsedCommandLine, parseJsonConfigFileContent, sys} from "typescript";
+import {IContext} from "./context";
+import {dirname} from "path";
+import {printDiagnostics} from "./print-diagnostics";
+import {convertDiagnostic} from "./tscache";
+import {getOptionsOverrides} from "./get-options-overrides";
+
+export function parseTsConfig(tsconfig: string, context: IContext): ParsedCommandLine {
+	const fileName = findConfigFile(process.cwd(), sys.fileExists, tsconfig);
+
+	if (!fileName)
+		throw new Error(`couldn't find '${tsconfig}' in ${process.cwd()}`);
+
+	const text = sys.readFile(fileName);
+	const result = parseConfigFileTextToJson(fileName, text);
+
+	if (result.error) {
+		printDiagnostics(context, convertDiagnostic("config", [result.error]));
+		throw new Error(`failed to parse ${fileName}`);
+	}
+
+	return parseJsonConfigFileContent(result.config, sys, dirname(fileName), getOptionsOverrides(), fileName);
+}

--- a/src/partial.ts
+++ b/src/partial.ts
@@ -1,0 +1,3 @@
+export declare type Partial<T> = {
+	[P in keyof T]?: T[P];
+};

--- a/src/print-diagnostics.ts
+++ b/src/print-diagnostics.ts
@@ -1,0 +1,41 @@
+import {DiagnosticCategory} from "typescript";
+import {red, white, yellow} from "colors/safe";
+import {each} from "lodash";
+import {IContext} from "./context";
+import {IDiagnostics} from "./tscache";
+
+export function printDiagnostics(context: IContext, diagnostics: IDiagnostics[]): void
+{
+	each(diagnostics, (diagnostic) =>
+	{
+		let print;
+		let color;
+		let category;
+		switch (diagnostic.category)
+		{
+			case DiagnosticCategory.Message:
+				print = context.info;
+				color = white;
+				category = "";
+				break;
+			case DiagnosticCategory.Error:
+				print = context.error;
+				color = red;
+				category = "error";
+				break;
+			case DiagnosticCategory.Warning:
+			default:
+				print = context.warn;
+				color = yellow;
+				category = "warning";
+				break;
+		}
+
+		const type = diagnostic.type + " ";
+
+		if (diagnostic.fileLine)
+			print.call(context, [`${diagnostic.fileLine}: ${type}${category} TS${diagnostic.code} ${color(diagnostic.flatMessage)}`]);
+		else
+			print.call(context, [`${type}${category} TS${diagnostic.code} ${color(diagnostic.flatMessage)}`]);
+	});
+}

--- a/src/rollupcontext.ts
+++ b/src/rollupcontext.ts
@@ -1,5 +1,5 @@
 import { IContext, IRollupContext, VerbosityLevel } from "./context";
-import * as _ from "lodash";
+import {isFunction} from "lodash";
 
 export class RollupContext implements IContext
 {
@@ -7,7 +7,7 @@ export class RollupContext implements IContext
 
 	constructor(private verbosity: VerbosityLevel, private bail: boolean, private context: IRollupContext, private prefix: string = "")
 	{
-		this.hasContext = _.isFunction(this.context.warn) && _.isFunction(this.context.error);
+		this.hasContext = isFunction(this.context.warn) && isFunction(this.context.error);
 	}
 
 	public warn(message: string): void

--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -148,10 +148,10 @@ export class TsCache
 		{
 			this.context.debug(colors.yellow("    cache miss"));
 
-			const data = transform();
-			this.codeCache.write(name, data);
+			const transformedData = transform();
+			this.codeCache.write(name, transformedData);
 			this.markAsDirty(id, snapshot);
-			return data;
+			return transformedData;
 		}
 
 		this.context.debug(colors.green("    cache hit"));
@@ -200,10 +200,10 @@ export class TsCache
 		{
 			this.context.debug(colors.yellow("    cache miss"));
 
-			const data = convertDiagnostic(type, check());
-			cache.write(name, data);
+			const convertedData = convertDiagnostic(type, check());
+			cache.write(name, convertedData);
 			this.markAsDirty(id, snapshot);
-			return data;
+			return convertedData;
 		}
 
 		this.context.debug(colors.green("    cache hit"));

--- a/src/tslib.ts
+++ b/src/tslib.ts
@@ -1,0 +1,15 @@
+import {readFileSync} from "fs";
+
+// The injected id for helpers.
+export const TSLIB = "tslib";
+export let tslibSource: string;
+try
+{
+	// tslint:disable-next-line:no-string-literal no-var-requires
+	const tslibPath = require.resolve("tslib/" + require("tslib/package.json")["module"]);
+	tslibSource = readFileSync(tslibPath, "utf8");
+} catch (e)
+{
+	console.warn("Error loading `tslib` helper library.");
+	throw e;
+}


### PR DESCRIPTION
# What is it

This PR makes the generated declaration files share the same directory root as the bundle generated by rollup.

Before, the declaration file would respect the *outDir* property of a `tsconfig.json` file and write declaration files to that directory.

This has two significant issues:
- If the *outDir* isn't the same as the generated .js files, Typescript doesn't know where to go look for the typings without manual work on the user's end.
- If more than one transform target is used in a rollup bundle (such as es2015 and umd), the declaration files will only be generated once and live outside the root of the generated folders

A previous PR has been submitted which unfortunately did not resolve this issue and, additionally, didn't handle scenarios where multiple compile targets are defined in the rollup configuration.

## What does it do

This is only relevant if the Typescript configuration has the compiler option `declaration: true`.

For the rollup configuration:
```javascript
export default {
	entry: ...,
	plugins: ...,
        sourceMap: true,
	targets: [
		{
			dest: "dist/umd/index.js",
			format: 'umd',
			moduleName: ...,
		},
		{
			dest: "dist/es2015/index.js",
			format: 'es',
		}
	]
};
```

...Which generates the destination folder structure:
```
dist
     es2015
          index.js
          index.js.map
     umd
          index.js
          index.js.map
```

...The declaration files will be rooted in the same directory:
```
dist
     es2015
          index.js
          index.js.map
          index.d.ts
     umd
          index.js
          index.js.map
          index.d.ts
```

## What it doesn't fix

The well-known issue remains where files that only export types are tree-shaken away before the `transform` hook of the plugin is ever called and thus it cannot generate declarations for those files. This is nothing new. Hopefully, we'll find a way someday.

## Other stuff

I've allowed myself to refactor a bit. Rather than import namespaces, as most modules did before, now named imports are used where possible. I've also fallen back to using the built-in `fs` module where possible rather than relying on `fs-extra` which is still used where required. I've moved some of the helper functions into separate files to make the code a bit easier to read.

I've also added more types to enforce stronger type-safety.