### PR TITLE
improve dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,12 +28,16 @@
   "dependencies": {
     "fs-extra": "^4.0.2",
     "tslib": "^1.7.1",
-    "resolve": "^1.4.0"
+    "resolve": "^1.4.0",
+    "rollup-pluginutils": "^2.0.1"
+  },
+  "peerDependencies": {
+    "rollup": "^0.50.0",
+    "typescript": "^2.0.0"
   },
   "devDependencies": {
     "typescript": "^2.5.3",
     "object-hash": "^1.1.8",
-    "rollup-pluginutils": "^2.0.1",
     "colors": "^1.1.2",
     "graphlib": "^2.1.1",
     "lodash": "^4.17.4",


### PR DESCRIPTION
After I upgrade to v0.6.0, it show me an error:

```
Error: Cannot find module 'rollup-pluginutils'
```

So I move `rollup-pluginutils` to _dependencies_.

BTW I add `typescript` and `rollup` to _peerDependencies_, so if user doesn't install it(or version incompatible), NPM will show a tip in console.