### PR TITLE
feat: Support rootDirs compiler option

### DIFF
--- a/dist/ioptions.d.ts
+++ b/dist/ioptions.d.ts
@@ -1,7 +1,7 @@
 import { tsModule } from "./tsproxy";
 export interface IOptions {
-    include: string;
-    exclude: string;
+    include: string | string[];
+    exclude: string | string[];
     check: boolean;
     verbosity: number;
     clean: boolean;

--- a/dist/rollup-plugin-typescript2.cjs.js
+++ b/dist/rollup-plugin-typescript2.cjs.js
@@ -17181,6 +17181,7 @@ var lodash_10 = lodash.concat;
 var lodash_11 = lodash.find;
 var lodash_12 = lodash.defaults;
 var lodash_14 = lodash.merge;
+var lodash_15 = lodash.flatMap;
 
 var RollupContext = /** @class */ (function () {
     function RollupContext(verbosity, bail, context, prefix) {
@@ -18466,9 +18467,9 @@ var objectHash_1 = createCommonjsModule(function (module, exports) {
  *
  * Options:
  *
- *  - `algorithm` hash algo to be used by this instance: *'sha1', 'md5' 
- *  - `excludeValues` {true|*false} hash object keys, values ignored 
- *  - `encoding` hash encoding, supports 'buffer', '*hex', 'binary', 'base64' 
+ *  - `algorithm` hash algo to be used by this instance: *'sha1', 'md5'
+ *  - `excludeValues` {true|*false} hash object keys, values ignored
+ *  - `encoding` hash encoding, supports 'buffer', '*hex', 'binary', 'base64'
  *  - `ignoreUnknown` {true|*false} ignore unknown object types
  *  - `replacer` optional function that replaces values before hashing
  *  - `respectFunctionProperties` {*true|false} consider function properties when hashing
@@ -18531,6 +18532,7 @@ function applyDefaults(object, options){
   options.unorderedArrays = options.unorderedArrays !== true ? false : true; // default to false
   options.unorderedSets = options.unorderedSets === false ? false : true; // default to false
   options.replacer = options.replacer || undefined;
+  options.excludeKeys = options.excludeKeys || undefined;
 
   if(typeof object === 'undefined') {
     throw new Error('Object argument required.');
@@ -18543,7 +18545,7 @@ function applyDefaults(object, options){
       options.algorithm = hashes[i];
     }
   }
-  
+
   if(hashes.indexOf(options.algorithm) === -1){
     throw new Error('Algorithm "' + options.algorithm + '"  not supported. ' +
       'supported values: ' + hashes.join(', '));
@@ -18554,7 +18556,7 @@ function applyDefaults(object, options){
     throw new Error('Encoding "' + options.encoding + '"  not supported. ' +
       'supported values: ' + encodings.join(', '));
   }
-  
+
   return options;
 }
 
@@ -18569,23 +18571,23 @@ function isNativeFunction(f) {
 
 function hash(object, options) {
   var hashingStream;
-  
+
   if (options.algorithm !== 'passthrough') {
     hashingStream = crypto.createHash(options.algorithm);
   } else {
     hashingStream = new PassThrough();
   }
-  
+
   if (typeof hashingStream.write === 'undefined') {
     hashingStream.write = hashingStream.update;
     hashingStream.end   = hashingStream.update;
   }
-  
+
   var hasher = typeHasher(options, hashingStream);
   hasher.dispatch(object);
   if (!hashingStream.update)
     hashingStream.end('');
-  
+
   if (hashingStream.digest) {
     return hashingStream.digest(options.encoding === 'buffer' ? undefined : options.encoding);
   }
@@ -18594,7 +18596,7 @@ function hash(object, options) {
   if (options.encoding === 'buffer') {
     return buf;
   }
-  
+
   return buf.toString(options.encoding);
 }
 
@@ -18611,9 +18613,9 @@ exports.writeToStream = function(object, options, stream) {
     stream = options;
     options = {};
   }
-  
+
   options = applyDefaults(object, options);
-  
+
   return typeHasher(options, stream).dispatch(object);
 };
 
@@ -18631,14 +18633,14 @@ function typeHasher(options, writeTo, context){
       if (options.replacer) {
         value = options.replacer(value);
       }
-      
+
       var type = typeof value;
       if (value === null) {
         type = 'null';
       }
 
       //console.log("[DEBUG] Dispatch: ", value, "->", type, " -> ", "_" + type);
-      
+
       return this['_' + type](value);
     },
     _object: function(object) {
@@ -18650,9 +18652,9 @@ function typeHasher(options, writeTo, context){
       } else {
         objType = objType[1]; // take only the class name
       }
-      
+
       objType = objType.toLowerCase();
-            
+
       var objectNumber = null;
 
       if ((objectNumber = context.indexOf(object)) >= 0) {
@@ -18660,7 +18662,7 @@ function typeHasher(options, writeTo, context){
       } else {
         context.push(object);
       }
-      
+
       if (typeof Buffer !== 'undefined' && Buffer.isBuffer && Buffer.isBuffer(object)) {
         write('buffer:');
         return write(object);
@@ -18686,7 +18688,11 @@ function typeHasher(options, writeTo, context){
         if (options.respectType !== false && !isNativeFunction(object)) {
           keys.splice(0, 0, 'prototype', '__proto__', 'constructor');
         }
-        
+
+        if (options.excludeKeys) {
+          keys = keys.filter(function(key) { return !options.excludeKeys(key); });
+        }
+
         write('object:' + keys.length + ':');
         var self = this;
         return keys.forEach(function(key){
@@ -18702,7 +18708,7 @@ function typeHasher(options, writeTo, context){
     _array: function(arr, unordered){
       unordered = typeof unordered !== 'undefined' ? unordered :
         options.unorderedArrays !== false; // default to options.unorderedArrays
-      
+
       var self = this;
       write('array:' + arr.length + ':');
       if (!unordered || arr.length <= 1) {
@@ -18710,7 +18716,7 @@ function typeHasher(options, writeTo, context){
           return self.dispatch(entry);
         });
       }
-      
+
       // the unordered case is a little more complicated:
       // since there is no canonical ordering on objects,
       // i.e. {a:1} < {a:2} and {a:1} > {a:2} are both false,
@@ -18764,7 +18770,7 @@ function typeHasher(options, writeTo, context){
         // have the same hash
         this.dispatch("function-name:" + String(fn.name));
       }
-      
+
       if (options.respectFunctionProperties) {
         this._object(fn);
       }
@@ -18841,7 +18847,7 @@ function typeHasher(options, writeTo, context){
       if (options.ignoreUnknown) {
         return write('[blob]');
       }
-      
+
       throw Error('Hashing Blob objects is currently not supported\n' +
         '(see https://github.com/puleos/object-hash/issues/26)\n' +
         'Use "options.replacer" or "options.ignoreUnknown"\n');
@@ -19783,6 +19789,19 @@ function typescript(options) {
             filter = createFilter(pluginOptions.include, pluginOptions.exclude);
             context.debug("rollup config: " + JSON.stringify(rollupOptions, undefined, 4));
             parsedConfig = parseTsConfig(pluginOptions.tsconfig, context, pluginOptions);
+            if (parsedConfig.options.rootDirs) {
+                var includedOptions = lodash_15(parsedConfig.options.rootDirs, function (res) {
+                    if (pluginOptions.include instanceof Array) {
+                        return pluginOptions.include.map(function (inc) {
+                            return res + "/" + inc;
+                        });
+                    }
+                    else {
+                        return res + "/" + pluginOptions.include;
+                    }
+                });
+                filter = createFilter(includedOptions, pluginOptions.exclude);
+            }
             servicesHost = new LanguageServiceHost(parsedConfig);
             service = tsModule.createLanguageService(servicesHost, tsModule.createDocumentRegistry());
             // printing compiler option errors

--- a/dist/rollup-plugin-typescript2.es.js
+++ b/dist/rollup-plugin-typescript2.es.js
@@ -17177,6 +17177,7 @@ var lodash_10 = lodash.concat;
 var lodash_11 = lodash.find;
 var lodash_12 = lodash.defaults;
 var lodash_14 = lodash.merge;
+var lodash_15 = lodash.flatMap;
 
 var RollupContext = /** @class */ (function () {
     function RollupContext(verbosity, bail, context, prefix) {
@@ -18462,9 +18463,9 @@ var objectHash_1 = createCommonjsModule(function (module, exports) {
  *
  * Options:
  *
- *  - `algorithm` hash algo to be used by this instance: *'sha1', 'md5' 
- *  - `excludeValues` {true|*false} hash object keys, values ignored 
- *  - `encoding` hash encoding, supports 'buffer', '*hex', 'binary', 'base64' 
+ *  - `algorithm` hash algo to be used by this instance: *'sha1', 'md5'
+ *  - `excludeValues` {true|*false} hash object keys, values ignored
+ *  - `encoding` hash encoding, supports 'buffer', '*hex', 'binary', 'base64'
  *  - `ignoreUnknown` {true|*false} ignore unknown object types
  *  - `replacer` optional function that replaces values before hashing
  *  - `respectFunctionProperties` {*true|false} consider function properties when hashing
@@ -18527,6 +18528,7 @@ function applyDefaults(object, options){
   options.unorderedArrays = options.unorderedArrays !== true ? false : true; // default to false
   options.unorderedSets = options.unorderedSets === false ? false : true; // default to false
   options.replacer = options.replacer || undefined;
+  options.excludeKeys = options.excludeKeys || undefined;
 
   if(typeof object === 'undefined') {
     throw new Error('Object argument required.');
@@ -18539,7 +18541,7 @@ function applyDefaults(object, options){
       options.algorithm = hashes[i];
     }
   }
-  
+
   if(hashes.indexOf(options.algorithm) === -1){
     throw new Error('Algorithm "' + options.algorithm + '"  not supported. ' +
       'supported values: ' + hashes.join(', '));
@@ -18550,7 +18552,7 @@ function applyDefaults(object, options){
     throw new Error('Encoding "' + options.encoding + '"  not supported. ' +
       'supported values: ' + encodings.join(', '));
   }
-  
+
   return options;
 }
 
@@ -18565,23 +18567,23 @@ function isNativeFunction(f) {
 
 function hash(object, options) {
   var hashingStream;
-  
+
   if (options.algorithm !== 'passthrough') {
     hashingStream = crypto.createHash(options.algorithm);
   } else {
     hashingStream = new PassThrough();
   }
-  
+
   if (typeof hashingStream.write === 'undefined') {
     hashingStream.write = hashingStream.update;
     hashingStream.end   = hashingStream.update;
   }
-  
+
   var hasher = typeHasher(options, hashingStream);
   hasher.dispatch(object);
   if (!hashingStream.update)
     hashingStream.end('');
-  
+
   if (hashingStream.digest) {
     return hashingStream.digest(options.encoding === 'buffer' ? undefined : options.encoding);
   }
@@ -18590,7 +18592,7 @@ function hash(object, options) {
   if (options.encoding === 'buffer') {
     return buf;
   }
-  
+
   return buf.toString(options.encoding);
 }
 
@@ -18607,9 +18609,9 @@ exports.writeToStream = function(object, options, stream) {
     stream = options;
     options = {};
   }
-  
+
   options = applyDefaults(object, options);
-  
+
   return typeHasher(options, stream).dispatch(object);
 };
 
@@ -18627,14 +18629,14 @@ function typeHasher(options, writeTo, context){
       if (options.replacer) {
         value = options.replacer(value);
       }
-      
+
       var type = typeof value;
       if (value === null) {
         type = 'null';
       }
 
       //console.log("[DEBUG] Dispatch: ", value, "->", type, " -> ", "_" + type);
-      
+
       return this['_' + type](value);
     },
     _object: function(object) {
@@ -18646,9 +18648,9 @@ function typeHasher(options, writeTo, context){
       } else {
         objType = objType[1]; // take only the class name
       }
-      
+
       objType = objType.toLowerCase();
-            
+
       var objectNumber = null;
 
       if ((objectNumber = context.indexOf(object)) >= 0) {
@@ -18656,7 +18658,7 @@ function typeHasher(options, writeTo, context){
       } else {
         context.push(object);
       }
-      
+
       if (typeof Buffer !== 'undefined' && Buffer.isBuffer && Buffer.isBuffer(object)) {
         write('buffer:');
         return write(object);
@@ -18682,7 +18684,11 @@ function typeHasher(options, writeTo, context){
         if (options.respectType !== false && !isNativeFunction(object)) {
           keys.splice(0, 0, 'prototype', '__proto__', 'constructor');
         }
-        
+
+        if (options.excludeKeys) {
+          keys = keys.filter(function(key) { return !options.excludeKeys(key); });
+        }
+
         write('object:' + keys.length + ':');
         var self = this;
         return keys.forEach(function(key){
@@ -18698,7 +18704,7 @@ function typeHasher(options, writeTo, context){
     _array: function(arr, unordered){
       unordered = typeof unordered !== 'undefined' ? unordered :
         options.unorderedArrays !== false; // default to options.unorderedArrays
-      
+
       var self = this;
       write('array:' + arr.length + ':');
       if (!unordered || arr.length <= 1) {
@@ -18706,7 +18712,7 @@ function typeHasher(options, writeTo, context){
           return self.dispatch(entry);
         });
       }
-      
+
       // the unordered case is a little more complicated:
       // since there is no canonical ordering on objects,
       // i.e. {a:1} < {a:2} and {a:1} > {a:2} are both false,
@@ -18760,7 +18766,7 @@ function typeHasher(options, writeTo, context){
         // have the same hash
         this.dispatch("function-name:" + String(fn.name));
       }
-      
+
       if (options.respectFunctionProperties) {
         this._object(fn);
       }
@@ -18837,7 +18843,7 @@ function typeHasher(options, writeTo, context){
       if (options.ignoreUnknown) {
         return write('[blob]');
       }
-      
+
       throw Error('Hashing Blob objects is currently not supported\n' +
         '(see https://github.com/puleos/object-hash/issues/26)\n' +
         'Use "options.replacer" or "options.ignoreUnknown"\n');
@@ -19779,6 +19785,19 @@ function typescript(options) {
             filter = createFilter(pluginOptions.include, pluginOptions.exclude);
             context.debug("rollup config: " + JSON.stringify(rollupOptions, undefined, 4));
             parsedConfig = parseTsConfig(pluginOptions.tsconfig, context, pluginOptions);
+            if (parsedConfig.options.rootDirs) {
+                var includedOptions = lodash_15(parsedConfig.options.rootDirs, function (res) {
+                    if (pluginOptions.include instanceof Array) {
+                        return pluginOptions.include.map(function (inc) {
+                            return res + "/" + inc;
+                        });
+                    }
+                    else {
+                        return res + "/" + pluginOptions.include;
+                    }
+                });
+                filter = createFilter(includedOptions, pluginOptions.exclude);
+            }
             servicesHost = new LanguageServiceHost(parsedConfig);
             service = tsModule.createLanguageService(servicesHost, tsModule.createDocumentRegistry());
             // printing compiler option errors

--- a/package.json
+++ b/package.json
@@ -11,8 +11,8 @@
     "src"
   ],
   "keywords": [
-	"rollup-plugin-typescript2",
-	"rollup-plugin-typescript",
+    "rollup-plugin-typescript2",
+    "rollup-plugin-typescript",
     "rollup-plugin",
     "typescript",
     "es2015",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -29,7 +29,7 @@ export default {
 				{
 					"graphlib": [ "alg", "Graph" ],
 					"colors/safe": [ "green", "white", "red", "yellow", "blue" ],
-					"lodash": [ "get", "each", "isEqual", "some", "filter", "endsWith", "map", "has", "isFunction", "concat", "find", "defaults", "assign", "merge" ],
+					"lodash": [ "get", "each", "isEqual", "some", "filter", "endsWith", "map", "has", "isFunction", "concat", "find", "defaults", "assign", "merge", "flatMap" ],
 				//	"fs-extra": [ "renameSync", "removeSync", "ensureFileSync", "writeJsonSync", "readJsonSync", "existsSync", "readdirSync", "emptyDirSync" ],
 				},
 			}

--- a/src/index.ts
+++ b/src/index.ts
@@ -77,6 +77,19 @@ export default function typescript(options?: Partial<IOptions>)
 
 			parsedConfig = parseTsConfig(pluginOptions.tsconfig, context, pluginOptions);
 
+			if (parsedConfig.options.rootDirs) {
+				const includedOptions = _.flatMap(parsedConfig.options.rootDirs, (res) => {
+					if (pluginOptions.include instanceof Array) {
+						return pluginOptions.include.map((inc) => {
+							return `${res}/${inc}`;
+						});
+					} else {
+						return `${res}/${pluginOptions.include}`;
+					}
+				});
+				filter = createFilter(includedOptions, pluginOptions.exclude);
+			}
+
 			servicesHost = new LanguageServiceHost(parsedConfig);
 
 			service = tsModule.createLanguageService(servicesHost, tsModule.createDocumentRegistry());

--- a/src/ioptions.ts
+++ b/src/ioptions.ts
@@ -2,8 +2,8 @@ import { tsModule } from "./tsproxy";
 
 export interface IOptions
 {
-	include: string;
-	exclude: string;
+	include: string|string[];
+	exclude: string|string[];
 	check: boolean;
 	verbosity: number;
 	clean: boolean;


### PR DESCRIPTION
Fixes #37 

The implementation is pretty straightforward: if a `rootDirs` tsconfig option is set, the filter is created by permuting and flat-mapping `rootDirs` and `include`.

So the default `include: ["*.ts+(|x)", "**/*.ts+(|x)"],`, along with `rootDirs: ["./src","../../shared/lib/src"]`, would create a filter for:

```
./src/*.ts+(|x)
./src/**/*.ts+(|x)
../../shared/lib/src/*.ts+(|x)
../../shared/lib/src/**/*.ts+(|x)
```

A user could also specify their own `include` as part of the plugin's configuration, and it should be applied correctly.

This works for my use case, but I don't have a very robust way of testing other project configurations, so you might want to test this more before releasing.

Cheers!