### PR TITLE
Set typescript as dependency instead of dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "lint": "tslint -c ./tslint.json src/*.ts ./*.js"
   },
   "dependencies": {
+	"typescript": "^2.9.1",
     "fs-extra": "^5.0.0",
     "resolve": "^1.7.1",
     "rollup-pluginutils": "^2.0.1",
@@ -40,7 +41,6 @@
     "typescript": ">=2.4.0"
   },
   "devDependencies": {
-    "typescript": "^2.9.1",
     "object-hash": "^1.3.0",
     "colors": "^1.2.4",
     "graphlib": "^2.1.5",


### PR DESCRIPTION
To fix #88 we must have typescript as dependency instead of a dev-dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ezolenko/rollup-plugin-typescript2/90)
<!-- Reviewable:end -->
