### PR TITLE
Add tsconfig error reporting

### DIFF
--- a/src/parse-tsconfig.ts
+++ b/src/parse-tsconfig.ts
@@ -21,6 +21,7 @@ export function parseTsConfig(context: IContext, pluginOptions: IOptions): tsTyp
 	let loadedConfig: any = {};
 	let baseDir = process.cwd();
 	let configFileName;
+	let pretty = false;
 	if (fileName)
 	{
 		const text = tsModule.sys.readFile(fileName);
@@ -28,10 +29,11 @@ export function parseTsConfig(context: IContext, pluginOptions: IOptions): tsTyp
 			throw new Error(`failed to read '${fileName}'`);
 
 		const result = tsModule.parseConfigFileTextToJson(fileName, text);
+		pretty = _.get(result.config, "pretty", pretty);
 
 		if (result.error !== undefined)
 		{
-			printDiagnostics(context, convertDiagnostic("config", [result.error]), _.get(result.config, "pretty", false));
+			printDiagnostics(context, convertDiagnostic("config", [result.error]), pretty);
 			throw new Error(`failed to parse '${fileName}'`);
 		}
 
@@ -47,6 +49,7 @@ export function parseTsConfig(context: IContext, pluginOptions: IOptions): tsTyp
 	const parsedTsConfig = tsModule.parseJsonConfigFileContent(mergedConfig, tsModule.sys, baseDir, compilerOptionsOverride, configFileName);
 
 	checkTsConfig(parsedTsConfig);
+	printDiagnostics(context, convertDiagnostic("config", parsedTsConfig.errors), pretty);
 
 	context.debug(`built-in options overrides: ${JSON.stringify(compilerOptionsOverride, undefined, 4)}`);
 	context.debug(`parsed tsconfig: ${JSON.stringify(parsedTsConfig, undefined, 4)}`);


### PR DESCRIPTION
Now prints fancy messages like this one:
```
rpt2: config error TS18003 No inputs were found in config file '<path>/tsconfig.json'. Specified 'include' paths were '["src/"]' and 'exclude' paths were '["node_modules/"]'.
```
Fixes #106