### PR TITLE
Update diagnostic message according to standard tool parsing.

### DIFF
--- a/src/print-diagnostics.ts
+++ b/src/print-diagnostics.ts
@@ -38,9 +38,9 @@ export function printDiagnostics(context: IContext, diagnostics: IDiagnostics[],
 		else
 		{
 			if (diagnostic.fileLine !== undefined)
-				print.call(context, `${diagnostic.fileLine}: ${type}${category} TS${diagnostic.code} ${color(diagnostic.flatMessage)}`);
+				print.call(context, `${diagnostic.fileLine}: ${type}${category} TS${diagnostic.code}: ${color(diagnostic.flatMessage)}`);
 			else
-				print.call(context, `${type}${category} TS${diagnostic.code} ${color(diagnostic.flatMessage)}`);
+				print.call(context, `${type}${category} TS${diagnostic.code}: ${color(diagnostic.flatMessage)}`);
 		}
 	});
 }


### PR DESCRIPTION
MSBuild and many other tools / IDEs will correctly parse the message if ":" is added right after the error code.

See https://blogs.msdn.microsoft.com/msbuild/2006/11/02/msbuild-visual-studio-aware-error-messages-and-message-formats/ for reference.