### PR TITLE
Fix extension name in babel config

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ import { DEFAULT_EXTENSIONS } from '@babel/core';
 	babel({
 		extensions: [
 			...DEFAULT_EXTENSIONS,
-			'ts',
-			'tsx'
+			'.ts',
+			'.tsx'
 		]
 	}),
 ...


### PR DESCRIPTION
An extension name should start with a `.` in the `extensions` option of babel config. (As described here: https://babeljs.io/docs/en/babel-core#default-extensions)