### PR TITLE
Add .js extension to virtual tslib

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import { IOptions } from "./ioptions";
 import { Partial } from "./partial";
 import { parseTsConfig } from "./parse-tsconfig";
 import { printDiagnostics } from "./print-diagnostics";
-import { TSLIB, tslibSource, tslibVersion } from "./tslib";
+import { TSLIB, TSLIB_VIRTUAL, tslibSource, tslibVersion } from "./tslib";
 import { blue, red, yellow, green } from "colors/safe";
 import { dirname, isAbsolute, join, relative } from "path";
 import { normalize } from "./normalize";
@@ -125,7 +125,7 @@ const typescript: PluginImpl<Partial<IOptions>> = (options) =>
 		resolveId(this: PluginContext, importee: string, importer: string | undefined)
 		{
 			if (importee === TSLIB)
-				return "\0" + TSLIB;
+				return TSLIB_VIRTUAL;
 
 			if (!importer)
 				return;
@@ -162,7 +162,7 @@ const typescript: PluginImpl<Partial<IOptions>> = (options) =>
 
 		load(id: string)
 		{
-			if (id === "\0" + TSLIB)
+			if (id === TSLIB_VIRTUAL)
 				return tslibSource;
 
 			return null;

--- a/src/tslib.ts
+++ b/src/tslib.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "fs";
 
 // The injected id for helpers.
 export const TSLIB = "tslib";
+export const TSLIB_VIRTUAL = "\0tslib.js";
 export let tslibSource: string;
 export let tslibVersion: string;
 try


### PR DESCRIPTION
Rollup has `preserveModules` option which is used to skip flat bundling and writing instead to disk a directory structure resembling the input one. This plugin makes tslib a "virtual" module by default - this means that it virtually creates an input file for Rollup to consume, but obviously it's not part of the input directory structure. To deal with it in combination with `preserveModules` Rollup creates a `_virtual` output directory and put such modules in it. As filename of such a virtual module it uses "as is" the given identifier - in this case `\0tslib`. Problem is that it doesn't add any extension to it and this trips other tools if you don't include the extension in the virtual identifier - i.e. webpack and it's resolving algorithm.