### PR TITLE
Upgrade rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "lodash": "4.17.15",
     "object-hash": "1.3.1",
     "rimraf": "3.0.0",
-    "rollup": "^1.20.3 ",
+    "rollup": "^1.25.1 ",
     "rollup-plugin-commonjs": "10.1.0",
     "rollup-plugin-node-resolve": "5.2.0",
     "rollup-plugin-re": "1.0.7",


### PR DESCRIPTION
With Rollup 1.25.1, the build (including build-self, multiple times) works again even with patch 551a14e773141cd993bb9d1ffd349c92481edf11 .

However, since the peerDependency still says `">=0.68.0"`, users might still run into issues when trying to run the plugin with an older Rollup that still has the bug. Should we also set the peer dep to the current version? Or consider Rollup bugs outside of the responsibility of the plugin? Or block on that? 