### PR TITLE
(fix): declaration maps should have correct sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The plugin inherits all compiler options and file lists from your `tsconfig.json
 * `noEmit`: false
 * `inlineSourceMap`: false (see [#71](https://github.com/ezolenko/rollup-plugin-typescript2/issues/71))
 * `outDir`: `./placeholder` in cache root, see [83](https://github.com/ezolenko/rollup-plugin-typescript2/issues/83) and [Microsoft/TypeScript/issues/24715](https://github.com/Microsoft/TypeScript/issues/24715)
-* `declarationDir`: `process.cwd()` (*only if `useTsconfigDeclarationDir` is false in the plugin options*)
+* `declarationDir`: Rollup's `output.file` or `output.dir` (*only if `useTsconfigDeclarationDir` is false in the plugin options*)
 * `moduleResolution`: `node` (*`classic` is [deprecated](https://www.typescriptlang.org/docs/handbook/module-resolution.html). It also breaks this plugin, see [#12](https://github.com/ezolenko/rollup-plugin-typescript2/issues/12) and [#14](https://github.com/ezolenko/rollup-plugin-typescript2/issues/14)*)
 * `allowNonTsExtensions`: true to let other plugins on the chain generate typescript, update plugin's include filter to pick them up (see [#111](https://github.com/ezolenko/rollup-plugin-typescript2/issues/111))
 

--- a/src/get-options-overrides.ts
+++ b/src/get-options-overrides.ts
@@ -6,7 +6,7 @@ import * as _ from "lodash";
 import { join } from "path";
 import { IContext } from "./context";
 
-export function getOptionsOverrides({ useTsconfigDeclarationDir, cacheRoot, cwd }: IOptions, preParsedTsconfig?: tsTypes.ParsedCommandLine): tsTypes.CompilerOptions
+export function getOptionsOverrides({ useTsconfigDeclarationDir, cacheRoot }: IOptions, preParsedTsconfig?: tsTypes.ParsedCommandLine): tsTypes.CompilerOptions
 {
 	const overrides: tsTypes.CompilerOptions = {
 		noEmitHelpers: false,
@@ -24,11 +24,9 @@ export function getOptionsOverrides({ useTsconfigDeclarationDir, cacheRoot, cwd 
 		if (preParsedTsconfig.options.module === undefined)
 			overrides.module = tsModule.ModuleKind.ES2015;
 
-		const declaration = preParsedTsconfig.options.declaration;
-		if (!declaration)
+		// only set declarationDir if useTsconfigDeclarationDir is enabled
+		if (!useTsconfigDeclarationDir)
 			overrides.declarationDir = undefined;
-		if (declaration && !useTsconfigDeclarationDir)
-			overrides.declarationDir = cwd;
 
 		// unsetting sourceRoot if sourceMap is not enabled (in case original tsconfig had inlineSourceMap set that is being unset and would cause TS5051)
 		const sourceMap = preParsedTsconfig.options.sourceMap;

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,11 +12,11 @@ import { parseTsConfig } from "./parse-tsconfig";
 import { printDiagnostics } from "./print-diagnostics";
 import { TSLIB, TSLIB_VIRTUAL, tslibSource, tslibVersion } from "./tslib";
 import { blue, red, yellow, green } from "colors/safe";
-import { relative } from "path";
+import { relative, dirname, resolve as pathResolve } from "path";
 import { normalize } from "./normalize";
 import { satisfies } from "semver";
 import findCacheDir from "find-cache-dir";
-import { PluginImpl, PluginContext, InputOptions, OutputOptions, MinimalPluginContext, TransformResult } from "rollup";
+import { PluginImpl, PluginContext, InputOptions, OutputOptions, MinimalPluginContext, TransformResult, SourceMap } from "rollup";
 import { createFilter } from "./get-options-overrides";
 
 type RPT2Options = Partial<IOptions>;
@@ -365,11 +365,27 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 				}
 				else
 				{
-					const relativePath = relative(pluginOptions.cwd, fileName);
+					// don't mutate the entry because generateBundle gets called multiple times
+					let entryText = entry.text
+					const declarationDir = (_output.file ? dirname(_output.file) : _output.dir) as string;
+					const cachePlaceholder = `${pluginOptions.cacheRoot}/placeholder`
+
+					// modify declaration map sources to correct relative path
+					if (extension === ".d.ts.map") {
+						const parsedText = JSON.parse(entryText) as SourceMap;
+						// invert back to absolute, then make relative to declarationDir
+						parsedText.sources = parsedText.sources.map(source => {
+							const absolutePath = pathResolve(cachePlaceholder, source);
+							return relative(declarationDir, absolutePath);
+						});
+						entryText = JSON.stringify(parsedText);
+					}
+
+					const relativePath = relative(cachePlaceholder, fileName);
 					context.debug(() => `${blue("emitting declarations")} for '${key}' to '${relativePath}'`);
 					this.emitFile({
 						type: "asset",
-						source: entry.text,
+						source: entryText,
 						fileName: relativePath,
 					});
 				}


### PR DESCRIPTION
- change declarationDir default to be Rollup's output destination
  instead of cwd
  - previously, it was set to cwd if useTsconfigDeclarationDir wasn't
    true, however, declarations aren't output to cwd, but to Rollup's
    output destination, so this was incorrect

- also change the one line in the docs that says it'll be
  `process.cwd()`; every other reference says it'll be the output dest

Fixes #204 and downstream https://github.com/jaredpalmer/tsdx/issues/479 . Better solution to downstream https://github.com/jaredpalmer/tsdx/issues/488

Couldn't change `get-options-overrides` because the `options` hook only gets `InputOptions`; it's not till `generateBundle` that we get access to `OutputOptions`.

RE: multiple output dirs: Rollup will call `generateBundle` for each output as far as I understand. `InputOptions` is passed to `rollup` which generates a `bundle` object, and `bundle.write` is called with each `OutputOptions` -- it's a [two step+ process](https://github.com/rollup/rollup/issues/3422#issuecomment-595706449). I think that's also why the type is `OutputOptions` and not `OutputOptions[]` (though the code doesn't use Rollup's `Plugin` interface; but that also defines it as `generateBundle` with just `OutputOptions`).

Would be great to add tests to ensure the declaration maps are correct now, but there doesn't seem to be any test set-up 😕 #135 seems to partially address that but was never completed.
Can see https://github.com/jaredpalmer/tsdx/pull/488 for how I tested `sources` there