### PR TITLE
stop roll() from failing if the new cache folder is not created

### DIFF
--- a/src/rollingcache.ts
+++ b/src/rollingcache.ts
@@ -98,6 +98,8 @@ export class RollingCache<DataType> implements ICache<DataType>
 
 		this.rolled = true;
 		removeSync(this.oldCacheRoot);
-		renameSync(this.newCacheRoot, this.oldCacheRoot);
+		if (fs.existsSync(this.newCacheRoot)) {
+			fs.renameSync(this.newCacheRoot, this.oldCacheRoot);
+		}
 	}
 }

--- a/src/rollingcache.ts
+++ b/src/rollingcache.ts
@@ -99,7 +99,7 @@ export class RollingCache<DataType> implements ICache<DataType>
 		this.rolled = true;
 		removeSync(this.oldCacheRoot);
 		if (existsSync(this.newCacheRoot)) {
-			fs.renameSync(this.newCacheRoot, this.oldCacheRoot);
+			renameSync(this.newCacheRoot, this.oldCacheRoot);
 		}
 	}
 }

--- a/src/rollingcache.ts
+++ b/src/rollingcache.ts
@@ -98,7 +98,7 @@ export class RollingCache<DataType> implements ICache<DataType>
 
 		this.rolled = true;
 		removeSync(this.oldCacheRoot);
-		if (fs.existsSync(this.newCacheRoot)) {
+		if (existsSync(this.newCacheRoot)) {
 			fs.renameSync(this.newCacheRoot, this.oldCacheRoot);
 		}
 	}


### PR DESCRIPTION
Today I stumbled upon an error where it would fail when the cache folder was not present
```(typescript) Error: ENOENT: no such file or directory, rename 'REDACTED\node_modules\.cache\rollup-plugin-typescript2/rpt2_759e2fd8d3f20c1a0805faf5404af6bea36632fd/code/cache_' -> 'REDACTED\node_modules\.cache\rollup-plugin-typescript2/rpt2_759e2fd8d3f20c1a0805faf5404af6bea36632fd/code/cache'```

This PR fixes it by checking its existence before trying to rename it