### PR TITLE
github: add spoiler tags to issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -11,16 +11,40 @@
 
 #### rollup.config.js
 
-<!--- paste your rollup config here if relevant --->
+<!--- paste your rollup config below if relevant --->
+<details>
+  <summary>`rollup.config.js`: </summary>
+
+<!--- INSERT rollup.config.js HERE --->
+
+</details>
 
 #### tsconfig.json
 
-<!--- paste your tsconfig.json here if relevant --->
+<!--- paste your tsconfig.json below if relevant --->
+<details>
+  <summary>`tsconfig.json`: </summary>
+
+<!--- INSERT tsconfig.json HERE --->
+
+</details>
 
 #### package.json
 
-<!--- paste your package.json here if relevant --->
+<!--- paste your package.json below if relevant --->
+<details>
+  <summary>`package.json`: </summary>
+
+<!--- INSERT package.json HERE --->
+
+</details>
 
 #### plugin output with verbosity 3
 
 <!--- add verbosity verbosity: 3 to plugin options and attach output if relevant (censor out anything sensitive) --->
+<details>
+  <summary>plugin output with verbosity 3: </summary>
+
+<!--- INSERT plugin output HERE or attach --->
+
+</details>


### PR DESCRIPTION
## Description

- long logs of output or long configs are hard on the eyes and make it
  difficult to read through issues as they just take up so much space
  - so it would be better, in my opinion, to hide them by default with
    spoiler tags, which can be opened up when further investigation is
    warranted

- some issue authors have already used this pattern, this just brings
  it to the template itself so everyone (hopefully) starts using it

## Tags

Can see examples of spoiler tag usage in #97, #148, and my own https://github.com/ezolenko/rollup-plugin-typescript2/issues/212#issuecomment-594248522

Can see examples of very long output logs and/or configs in #72, #85, #87, #194,  #213, #217

## Review Notes

Been meaning to write this PR for quite a while actually, finally got to it 😅 