### PR TITLE
github: use envinfo for getting versions in issue reports

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,13 +1,22 @@
 #### What happens and why it is wrong
 
-#### Environment 
+#### Environment
 
 <!--- describe your environment if it is relevant to the problem --->
 
-#### Versions
-- typescript:
-- rollup:
-- rollup-plugin-typescript2:
+##### Versions
+
+<!--
+  PLEASE RUN THIS COMMAND INSIDE YOUR PROJECT:
+
+  npx envinfo --npmPackages typescript,rollup,rollup-plugin-typescript2
+
+  AND PASTE ITS CONTENTS BELOW INSIDE THE CODE SNIPPET vvvvvvvvv
+-->
+
+```text
+
+```
 
 #### rollup.config.js
 


### PR DESCRIPTION
## Description

- replace the version list with a copy+paste this envinfo command,
  copy back the output
  - uses a modified, shortened variant of something being used
    successfully downstream in TSDX: https://github.com/formium/tsdx/commit/349f299976141c7d4f0a71b22d998319e54a3c9d
- this should make reporting versions zero-effort and thereby
  significantly decrease non-reporting by making the hard thing easy
  - personally have experienced issues that didn't report but version
    was very relevant to the issue
  - also some folks report "latest" or used carets, which lack posterity
    or are confusing

## Tags

Modified, shortened variant of https://github.com/formium/tsdx/pull/820

## Output Example

It looks like this when running in TSDX for example:

```bash
$ npx envinfo --npmPackages typescript,rollup,rollup-plugin-typescript2
npx: installed 1 in 0.951s

  npmPackages:
    rollup: ^1.32.1 => 1.32.1 
    rollup-plugin-typescript2: ^0.26.0 => 0.26.0 
    typescript: ^3.7.3 => 3.7.3 
```