### PR TITLE
fix: use compilerOptions.rootDir to filter files

### DIFF
--- a/src/get-options-overrides.ts
+++ b/src/get-options-overrides.ts
@@ -71,5 +71,5 @@ export function createFilter(context: IContext, pluginOptions: IOptions, parsedC
 
 	context.debug(() => `included:\n${JSON.stringify(included, undefined, 4)}`);
 	context.debug(() => `excluded:\n${JSON.stringify(excluded, undefined, 4)}`);
-	return createRollupFilter(included, excluded);
+	return createRollupFilter(included, excluded, { resolve: parsedConfig.options.rootDir });
 }


### PR DESCRIPTION
When compilerOptions.rootDir is specified, it is used instead of process.cwd() to filter files. 

Possible fix for #237