### PR TITLE
Fix duplicate output with multiple entry points

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { parseTsConfig } from "./parse-tsconfig";
 import { printDiagnostics } from "./print-diagnostics";
 import { TSLIB, TSLIB_VIRTUAL, tslibSource, tslibVersion } from "./tslib";
 import { blue, red, yellow, green } from "colors/safe";
-import { relative, dirname, resolve as pathResolve } from "path";
+import { relative, dirname, normalize as pathNormalize, resolve as pathResolve } from "path";
 import { normalize } from "./normalize";
 import { satisfies } from "semver";
 import findCacheDir from "find-cache-dir";
@@ -166,7 +166,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 				context.debug(() => `${blue("resolving")} '${importee}' imported by '${importer}'`);
 				context.debug(() => `    to '${resolved}'`);
 
-				return resolved;
+				return pathNormalize(resolved);
 			}
 
 			return;


### PR DESCRIPTION
On Windows the normalized paths in resolveId end up in POSIX format.
This cause rollup to treat the returned path as a new piece of content.
This in turn results in duplicate output for references across entry points.

Fixed by normalizing the path to use host OS separators before returning.

See https://github.com/antross/rollup-plugin-typescript2-repro for a repro project.