### PR TITLE
Add tslib to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ This version is somewhat slower than original, but it will print out typescript 
 ```bash
 # with npm
 npm install rollup-plugin-typescript2 typescript --save-dev
-# with yarn
+# with yarn berry
+yarn add rollup-plugin-typescript2 typescript tslib --dev
+# with classic yarn
 yarn add rollup-plugin-typescript2 typescript --dev
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,9 @@ This version is somewhat slower than original, but it will print out typescript 
 
 ```bash
 # with npm
-npm install rollup-plugin-typescript2 typescript --save-dev
-# with yarn berry
+npm install rollup-plugin-typescript2 typescript tslib --save-dev
+# with yarn
 yarn add rollup-plugin-typescript2 typescript tslib --dev
-# with classic yarn
-yarn add rollup-plugin-typescript2 typescript --dev
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "@rollup/pluginutils": "^3.1.0",
     "find-cache-dir": "^3.3.1",
     "fs-extra": "8.1.0",
-    "resolve": "1.17.0"
+    "resolve": "1.17.0",
+    "tslib": "2.0.1"
   },
   "peerDependencies": {
     "rollup": ">=1.26.3",
-    "typescript": ">=2.4.0",
-    "tslib": ">=2.0.0"
+    "typescript": ">=2.4.0"
   },
   "devDependencies": {
     "@types/colors": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -32,12 +32,12 @@
     "@rollup/pluginutils": "^3.1.0",
     "find-cache-dir": "^3.3.1",
     "fs-extra": "8.1.0",
-    "resolve": "1.17.0",
-    "tslib": "2.0.1"
+    "resolve": "1.17.0"
   },
   "peerDependencies": {
     "rollup": ">=1.26.3",
-    "typescript": ">=2.4.0"
+    "typescript": ">=2.4.0",
+    "tslib": ">=2.0.0"
   },
   "devDependencies": {
     "@types/colors": "1.2.1",


### PR DESCRIPTION
Version 2 of yarn uses Plug'n'Play, which means that the user's installed `typescript` (which is used because `typescript` is set as a peer dependency for this plugin) won't have access to the `tslib` marked as a dependency for this plugin.

https://github.com/yarnpkg/berry/issues/2140

People using version 2 of yarn have to manually install `tslib` in `devDependencies`. This PR makes it so that everyone would need to manually install `tslib` as well, which is what should actually happen.