### PR TITLE
Add `trace` method to the `LanguageServiceHost` to enable usage with `traceResolution`

### DIFF
--- a/src/host.ts
+++ b/src/host.ts
@@ -145,4 +145,8 @@ export class LanguageServiceHost implements tsTypes.LanguageServiceHost
 
 		return transformer;
 	}
+
+	public trace(line: string) {
+		console.log(line)
+	}
 }


### PR DESCRIPTION
At the moment I'm debugging a weird difference in behavior between `tsc` and `tsdx` (where the latter is using this plugin) and being able to look through the output of `traceResolution` is super helpful for me - but I had to patch this plugin locally to make it work. It would be great if this option would just be respected by the plugin.