### PR TITLE
fix(github): improve formatting of issue template spoilers

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -18,42 +18,50 @@
 
 ```
 
-#### rollup.config.js
-
 <!--- paste your rollup config below if relevant --->
 <details>
-  <summary>`rollup.config.js`: </summary>
+  <summary><h4><code>rollup.config.js</code></h4>: </summary>
 
-<!--- INSERT rollup.config.js HERE --->
+<!--- INSERT rollup.config.ts IN THE CODE SNIPPET BELOW --->
+
+```js
+
+```
 
 </details>
-
-#### tsconfig.json
 
 <!--- paste your tsconfig.json below if relevant --->
 <details>
-  <summary>`tsconfig.json`: </summary>
+  <summary><h4><code>tsconfig.json</code></h4>: </summary>
 
-<!--- INSERT tsconfig.json HERE --->
+<!--- INSERT tsconfig.json IN THE CODE SNIPPET BELOW --->
+
+```json5
+
+```
 
 </details>
-
-#### package.json
 
 <!--- paste your package.json below if relevant --->
 <details>
-  <summary>`package.json`: </summary>
+  <summary><h4><code>package.json</code></h4>: </summary>
 
-<!--- INSERT package.json HERE --->
+<!--- INSERT package.json IN THE CODE SNIPPET BELOW --->
+
+```json
+
+```
 
 </details>
 
-#### plugin output with verbosity 3
-
 <!--- add verbosity verbosity: 3 to plugin options and attach output if relevant (censor out anything sensitive) --->
 <details>
-  <summary>plugin output with verbosity 3: </summary>
+  <summary><h4>plugin output with verbosity 3</h4>: </summary>
 
-<!--- INSERT plugin output HERE or attach --->
+<!--- INSERT plugin output IN THE CODE SNIPPET BELOW or attach --->
+
+```text
+
+```
 
 </details>


### PR DESCRIPTION
## Summary

Improve formatting of the issue template with code blocks and fixing some duplication

## Details

- I originally added the spoilers in #244 and while they work (and I would say improve readability a good bit), there's also some issues with them
  - I've used them a ton more now so know how to workaround most of the issues with them now

- fix: use HTML `code` tag inside of `summary` tag, can't use backticks
  - was mixing MD and HTML before, and this doesn't always work and didn't work on GitHub, they just had visible backticks before

- fix: don't duplicate the file name in the heading, just make the `summary` have a heading inside it instead
  - use an `h4` same as the `####` that it was before

- feat: add syntax highlighting by adding code blocks for each code snippet
  - `js` for `rollup.config.js`, `json5` for `tsconfig` (it has comments, trailing commas, etc (actually a custom parser, but json5 is close enough)), `json` for `package.json`, and `text` for verbose logs
  - also, a lot of people sometimes just paste the code with no code block and it formats terribly, so this should help defer that (as well as any potential issues that can crop up with unindented blocks)
    - the `envinfo` `text` code block that I added in #245 seems to be working well and used in most issues, so hopefully this will improve issues too
    
## References

I wrote #310 using this format as an example! Think it's a good bit cleaner

- As for examples of how it previously looked and why this is better, #309 shows an example with no syntax highlighting but use of code blocks, whereas #306 uses no code blocks at all and so isn't formatted well and GitHub/Markdown doesn't indent it either. Both are properly using spoilers as well.