### PR TITLE
fix(docs): `_.merge` doesn't concat arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ See [#108](https://github.com/ezolenko/rollup-plugin-typescript2/issues/108)
 	]
 	```
 
-	This is a [deep merge](https://lodash.com/docs/4.17.4#merge) (objects are merged, arrays are concatenated, primitives are replaced, etc), increase `verbosity` to 3 and look for `parsed tsconfig` if you get something unexpected.
+	This is a [deep merge](https://lodash.com/docs/4.17.4#merge) (objects are merged, arrays are merged by index, primitives are replaced, etc), increase `verbosity` to 3 and look for `parsed tsconfig` if you get something unexpected.
 
 * `tsconfig`: `undefined`
 


### PR DESCRIPTION
## Summary

Small change to the docs to fix a reference to how `_.merge` deep merges work with arrays

## Details

- it's a deep merge that merges them by index
- Per https://github.com/ezolenko/rollup-plugin-typescript2/issues/226#issuecomment-633108024 , the rest of the docs are accurate, just this one mention was incorrect

- Per https://github.com/ezolenko/rollup-plugin-typescript2/issues/86#issuecomment-1116144443 , eventually should move to shallow merge/replace arrays to better reflect how `tsconfig` `extends` works (and principle of least surprise), but just fix the docs for now

## References

Will be closing out #226 after this as it duplicates #86 otherwise
- I would've made this PR like 2 years ago to fix the docs, but unfortunately when randos on the internet are abusive to you because they only believe in their own opinion and then don't contribute anything anyway, it is not very motivational, to say the absolute least 😕  (see also my current status)