### PR TITLE
docs: clarify the TS option's defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,12 +168,12 @@ See [#108](https://github.com/ezolenko/rollup-plugin-typescript2/issues/108)
 * `useTsconfigDeclarationDir`: false
 
 	If true, declaration files will be emitted in the directory given in the tsconfig. If false, the declaration files will be placed inside the destination directory given in the Rollup configuration.
-	
+
 	Set to false if any other rollup plugins need access to declaration files.
 
-* `typescript`: typescript module installed with the plugin
+* `typescript`: peerDependency
 
-	When typescript version installed by the plugin (latest 2.x) is unacceptable, you can import your own typescript module and pass it in as `typescript: require("path/to/other/typescript")`. Must be 2.0+, things might break if transpiler interfaces changed enough from what the plugin was built against.
+	If you'd like to use a different version of TS than the peerDependency, you can import a different TypeScript module and pass it in as `typescript: require("path/to/other/typescript")`. Must be TS 2.0+, things might break if transpiler interfaces changed enough from what the plugin was built against.
 
 * `transformers`: `undefined`
 


### PR DESCRIPTION
## Summary

Be more clear about what the TS option does and what its default is -- the current peerDependency installed

## Details

- "latest 2.x" is no longer accurate and quite outdated (we're on `4.x` now), so just say it's the peerDep instead
  - @rollup/plugin-typescript calls the default a peerDep too: https://github.com/rollup/plugins/tree/master/packages/typescript#typescript

- be more specific that you can pass in a different version or fork of TS (like `ttypescript`) through this option
  - follow-up to 8ec49c78f523687deaf6816bc2ea320f16e325c7 and #252

Unrelated:
- auto-trim some whitespace-only lines
  - my editor does this automatically, and most of the README has trimmed whitespace anyway, so this keeps it consistent