### PR TITLE
docs: add link to NPM in monthly downloads badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # rollup-plugin-typescript2
 
 [![npm-version](https://img.shields.io/npm/v/rollup-plugin-typescript2.svg?maxAge=259200)](https://npmjs.org/package/rollup-plugin-typescript2)
-![npm-monthly-downloads](https://img.shields.io/npm/dm/rollup-plugin-typescript2.svg?maxAge=259200)
+[![npm-monthly-downloads](https://img.shields.io/npm/dm/rollup-plugin-typescript2.svg?maxAge=259200)](https://npmjs.org/package/rollup-plugin-typescript2)
 [![Node.js CI](https://github.com/ezolenko/rollup-plugin-typescript2/workflows/Node.js%20CI/badge.svg)](https://github.com/ezolenko/rollup-plugin-typescript2/actions?query=workflow%3A"Node.js+CI")
 
 Rollup plugin for typescript with compiler errors.


### PR DESCRIPTION
## Summary

Adds a link to NPM in the monthly downloads badge

## Details

- previously it just linked to the image itself; better to link to the source of the stats which is NPM
  - duplicates the other badge's link, but nbd, better than linking to an image imo
  
## Misc Notes

Should be the last of my very tiny docs PRs for now 😅  I split them up so that they're easier to merge/review as they're all independent changes from each other.