### PR TITLE
deps: remove unneeded `@types/colors` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rollup-plugin-typescript2",
-  "version": "0.31.3",
+  "version": "0.32.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rollup-plugin-typescript2",
-      "version": "0.31.3",
+      "version": "0.32.0",
       "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^4.1.2",
@@ -19,7 +19,6 @@
       "devDependencies": {
         "@rollup/plugin-commonjs": "21.1.0",
         "@rollup/plugin-node-resolve": "13.2.1",
-        "@types/colors": "1.2.1",
         "@types/find-cache-dir": "^2.0.0",
         "@types/fs-extra": "8.0.1",
         "@types/graphlib": "2.1.7",
@@ -213,16 +212,6 @@
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
       "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
       "peer": true
-    },
-    "node_modules/@types/colors": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/colors/-/colors-1.2.1.tgz",
-      "integrity": "sha512-7jNkpfN2lVO07nJ1RWzyMnNhH/I5N9iWuMPx9pedptxJ4MODf8rRV0lbJi6RakQ4sKQk231Fw4e2W9n3D7gZ3w==",
-      "deprecated": "This is a stub types definition. colors provides its own type definitions, so you don't need this installed.",
-      "dev": true,
-      "dependencies": {
-        "colors": "*"
-      }
     },
     "node_modules/@types/estree": {
       "version": "0.0.39",
@@ -1303,15 +1292,6 @@
       "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.36.tgz",
       "integrity": "sha512-HBNx4lhkxN7bx6P0++W8E289foSu8kO8GCk2unhuVggO+cE7rh9DhZUyPhUxNRG9m+5B5BTKxZQ5ZP92x/mx9Q==",
       "peer": true
-    },
-    "@types/colors": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@types/colors/-/colors-1.2.1.tgz",
-      "integrity": "sha512-7jNkpfN2lVO07nJ1RWzyMnNhH/I5N9iWuMPx9pedptxJ4MODf8rRV0lbJi6RakQ4sKQk231Fw4e2W9n3D7gZ3w==",
-      "dev": true,
-      "requires": {
-        "colors": "*"
-      }
     },
     "@types/estree": {
       "version": "0.0.39",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "typescript": ">=2.4.0"
   },
   "devDependencies": {
-    "@types/colors": "1.2.1",
+    "@rollup/plugin-commonjs": "21.1.0",
+    "@rollup/plugin-node-resolve": "13.2.1",
     "@types/find-cache-dir": "^2.0.0",
     "@types/fs-extra": "8.0.1",
     "@types/graphlib": "2.1.7",
@@ -56,8 +57,6 @@
     "object-hash": "3.0.0",
     "rimraf": "3.0.2",
     "rollup": "^2.70.2",
-    "@rollup/plugin-commonjs": "21.1.0",
-    "@rollup/plugin-node-resolve": "13.2.1",
     "rollup-plugin-re": "1.0.7",
     "rollup-plugin-typescript2": "0.31.2",
     "tslint": "6.1.3",


### PR DESCRIPTION
## Summary

Remove `@types/colors` from devDeps as it's no longer necessary

## Details

- it had a deprecation warning on install stating that types were built-in now
  - confirmed that my editor picks up the types fine without and that builds still work

- auto-alphabetize deps
- update `package-lock.json` version to match `package.json` version
  - NPM did both of these automatically when I ran `npm install`