### PR TITLE
deps: use `normalizePath` from `@rollup/pluginutils`

### DIFF
--- a/dist/normalize.d.ts
+++ b/dist/normalize.d.ts
@@ -1,2 +1,0 @@
-export declare function normalize(fileName: string): string;
-//# sourceMappingURL=normalize.d.ts.map

--- a/dist/normalize.d.ts.map
+++ b/dist/normalize.d.ts.map
@@ -1,1 +1,0 @@
-{"version":3,"file":"normalize.d.ts","sourceRoot":"","sources":["../src/normalize.ts"],"names":[],"mappings":"AAAA,wBAAgB,SAAS,CAAC,QAAQ,EAAE,MAAM,UAGzC"}

--- a/src/host.ts
+++ b/src/host.ts
@@ -1,7 +1,7 @@
 import { tsModule } from "./tsproxy";
 import * as tsTypes from "typescript";
 import * as _ from "lodash";
-import { normalize } from "./normalize";
+import { normalizePath as normalize } from "@rollup/pluginutils";
 import { TransformerFactoryCreator } from "./ioptions";
 
 export class LanguageServiceHost implements tsTypes.LanguageServiceHost

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import { printDiagnostics } from "./print-diagnostics";
 import { TSLIB, TSLIB_VIRTUAL, tslibSource, tslibVersion } from "./tslib";
 import { blue, red, yellow, green } from "colors/safe";
 import { relative, dirname, normalize as pathNormalize, resolve as pathResolve } from "path";
-import { normalize } from "./normalize";
+import { normalizePath as normalize } from "@rollup/pluginutils";
 import findCacheDir from "find-cache-dir";
 
 import { PluginImpl, PluginContext, InputOptions, OutputOptions, TransformResult, SourceMap, Plugin } from "rollup";

--- a/src/normalize.ts
+++ b/src/normalize.ts
@@ -1,4 +1,0 @@
-export function normalize(fileName: string)
-{
-	return fileName.split("\\").join("/");
-}


### PR DESCRIPTION
## Summary

Replaces `normalize.ts` with `normalizePath` from `@rollup/pluginutils`

## Description

- this was introduced in [`v4.1.0`](https://github.com/rollup/plugins/blob/master/packages/pluginutils/CHANGELOG.md#v410) of `@rollup/pluginutils` in https://github.com/rollup/plugins/pull/550
  - we're currently on `^4.1.2` for reference

- this is the same as the code in `normalize.ts` but it uses constants from Node and is used by multiple Rollup plugins, so just helps with standardization
  - also less code and types to ship in the bundle!

- removed the dist files for `normalize` as well, but didn't do a build in this commit as those are usually done in separate commits