### PR TITLE
clean: remove `partial.ts` as this is built into TS

### DIFF
--- a/dist/partial.d.ts
+++ b/dist/partial.d.ts
@@ -1,4 +1,0 @@
-export declare type Partial<T> = {
-    [P in keyof T]?: T[P];
-};
-//# sourceMappingURL=partial.d.ts.map

--- a/dist/partial.d.ts.map
+++ b/dist/partial.d.ts.map
@@ -1,1 +1,0 @@
-{"version":3,"file":"partial.d.ts","sourceRoot":"","sources":["../src/partial.ts"],"names":[],"mappings":"AAAA,MAAM,CAAC,OAAO,MAAM,OAAO,CAAC,CAAC,IAAI;KAAG,CAAC,IAAI,MAAM,CAAC,CAAC,CAAC,EAAE,CAAC,CAAC,CAAC,CAAC;CAAG,CAAC"}

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import * as tsTypes from "typescript";
 import * as resolve from "resolve";
 import * as _ from "lodash";
 import { IOptions } from "./ioptions";
-import { Partial } from "./partial";
 import { parseTsConfig } from "./parse-tsconfig";
 import { printDiagnostics } from "./print-diagnostics";
 import { TSLIB, TSLIB_VIRTUAL, tslibSource, tslibVersion } from "./tslib";

--- a/src/partial.ts
+++ b/src/partial.ts
@@ -1,1 +1,0 @@
-export declare type Partial<T> = { [P in keyof T]?: T[P]; };


### PR DESCRIPTION
## Summary

`Partial` is built into TS, so clean up & remove `partial.ts`

## Details

- Built-in at least as of TS 2.1: https://www.typescriptlang.org/docs/handbook/utility-types.html#partialtype
  - we have a peerDep on TS >=2.4, so should definitely be compatible
  - and TS is on ~4.6 at this point, so that's _really_ old

- remove the file and the declarations and declaration maps
  - don't rebuild as that's usually done as a separate commit