### PR TITLE
optim(ci): use `npm ci` for install and cache `npm`

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -22,10 +22,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
+      uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install
+        cache: 'npm'
+    - run: npm ci
     - run: npm run build
     - run: npm run build-self
     - run: npm run build-self


### PR DESCRIPTION
## Summary

Optimize CI by using `npm ci` and caching `npm` installs

## Details

- `npm ci` is installation for, well, CI, and is a good bit faster
  - c.f. https://docs.npmjs.com/cli/v8/commands/npm-ci

- cache `npm` installation with `setup-node` for speedier installs
  - upgrade `setup-node` as this was released in [v2.2.0](https://github.com/actions/setup-node/releases/tag/v2.2.0)