### PR TITLE
deps: upgrade `tslib` to `^2.4.0`, remove `@yarn-tool/resolve-package`

### DIFF
--- a/__tests__/tslib.spec.ts
+++ b/__tests__/tslib.spec.ts
@@ -1,0 +1,11 @@
+import { test, expect } from "@jest/globals";
+import * as fs from "fs-extra";
+
+import { tslibVersion, tslibSource } from "../src/tslib";
+
+test("tslib", async () => {
+  expect(tslibVersion).toEqual(require("tslib/package.json").version);
+
+  const tslibES6 = await fs.readFile(require.resolve("tslib/tslib.es6.js"), "utf8");
+  expect(tslibSource).toEqual(tslibES6);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,11 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^4.1.2",
-        "@yarn-tool/resolve-package": "^1.0.40",
         "find-cache-dir": "^3.3.2",
         "fs-extra": "^10.0.0",
         "resolve": "^1.20.0",
-        "tslib": "^2.3.1"
+        "tslib": "^2.4.0"
       },
       "devDependencies": {
         "@jest/globals": "^28.0.3",
@@ -1396,6 +1395,7 @@
     },
     "node_modules/@ts-type/package-dts": {
       "version": "1.0.56",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@types/semver": "^7.3.9",
@@ -1404,10 +1404,12 @@
     },
     "node_modules/@ts-type/package-dts/node_modules/@types/semver": {
       "version": "7.3.9",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@ts-type/package-dts/node_modules/ts-type": {
       "version": "2.1.2",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.1",
@@ -1462,6 +1464,7 @@
     },
     "node_modules/@types/bluebird": {
       "version": "3.5.36",
+      "dev": true,
       "license": "MIT",
       "peer": true
     },
@@ -1538,6 +1541,7 @@
     },
     "node_modules/@types/node": {
       "version": "8.0.47",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/object-hash": {
@@ -1590,6 +1594,7 @@
     },
     "node_modules/@yarn-tool/resolve-package": {
       "version": "1.0.40",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "@ts-type/package-dts": "^1.0.56",
@@ -1600,6 +1605,7 @@
     },
     "node_modules/@yarn-tool/resolve-package/node_modules/find-up": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -1614,6 +1620,7 @@
     },
     "node_modules/@yarn-tool/resolve-package/node_modules/locate-path": {
       "version": "6.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -1627,6 +1634,7 @@
     },
     "node_modules/@yarn-tool/resolve-package/node_modules/p-limit": {
       "version": "3.1.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -1640,6 +1648,7 @@
     },
     "node_modules/@yarn-tool/resolve-package/node_modules/p-locate": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -1653,6 +1662,7 @@
     },
     "node_modules/@yarn-tool/resolve-package/node_modules/pkg-dir": {
       "version": "5.0.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "find-up": "^5.0.0"
@@ -1663,6 +1673,7 @@
     },
     "node_modules/@yarn-tool/resolve-package/node_modules/upath2": {
       "version": "3.1.10",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "lodash": "^4.17.21",
@@ -4841,6 +4852,7 @@
     },
     "node_modules/lodash": {
       "version": "4.17.21",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.memoize": {
@@ -5100,6 +5112,7 @@
     },
     "node_modules/path-is-network-drive": {
       "version": "1.0.10",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.1"
@@ -5120,6 +5133,7 @@
     },
     "node_modules/path-strip-sep": {
       "version": "1.0.7",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "tslib": "^2.3.1"
@@ -5670,12 +5684,14 @@
     },
     "node_modules/ts-toolbelt": {
       "version": "9.6.0",
+      "dev": true,
       "license": "Apache-2.0",
       "peer": true
     },
     "node_modules/tslib": {
-      "version": "2.3.1",
-      "license": "0BSD"
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/tslint": {
       "version": "6.1.3",
@@ -5758,6 +5774,7 @@
     },
     "node_modules/typedarray-dts": {
       "version": "1.0.0",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/typescript": {
@@ -5943,6 +5960,7 @@
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6976,16 +6994,19 @@
     },
     "@ts-type/package-dts": {
       "version": "1.0.56",
+      "dev": true,
       "requires": {
         "@types/semver": "^7.3.9",
         "ts-type": "^2.1.2"
       },
       "dependencies": {
         "@types/semver": {
-          "version": "7.3.9"
+          "version": "7.3.9",
+          "dev": true
         },
         "ts-type": {
           "version": "2.1.2",
+          "dev": true,
           "requires": {
             "tslib": "^2.3.1",
             "typedarray-dts": "^1.0.0"
@@ -7036,6 +7057,7 @@
     },
     "@types/bluebird": {
       "version": "3.5.36",
+      "dev": true,
       "peer": true
     },
     "@types/estree": {
@@ -7105,7 +7127,8 @@
       "dev": true
     },
     "@types/node": {
-      "version": "8.0.47"
+      "version": "8.0.47",
+      "dev": true
     },
     "@types/object-hash": {
       "version": "1.3.3",
@@ -7154,6 +7177,7 @@
     },
     "@yarn-tool/resolve-package": {
       "version": "1.0.40",
+      "dev": true,
       "requires": {
         "@ts-type/package-dts": "^1.0.56",
         "pkg-dir": "< 6 >= 5",
@@ -7163,6 +7187,7 @@
       "dependencies": {
         "find-up": {
           "version": "5.0.0",
+          "dev": true,
           "requires": {
             "locate-path": "^6.0.0",
             "path-exists": "^4.0.0"
@@ -7170,30 +7195,35 @@
         },
         "locate-path": {
           "version": "6.0.0",
+          "dev": true,
           "requires": {
             "p-locate": "^5.0.0"
           }
         },
         "p-limit": {
           "version": "3.1.0",
+          "dev": true,
           "requires": {
             "yocto-queue": "^0.1.0"
           }
         },
         "p-locate": {
           "version": "5.0.0",
+          "dev": true,
           "requires": {
             "p-limit": "^3.0.2"
           }
         },
         "pkg-dir": {
           "version": "5.0.0",
+          "dev": true,
           "requires": {
             "find-up": "^5.0.0"
           }
         },
         "upath2": {
           "version": "3.1.10",
+          "dev": true,
           "requires": {
             "lodash": "^4.17.21",
             "path-is-network-drive": "^1.0.10",
@@ -9524,7 +9554,8 @@
       }
     },
     "lodash": {
-      "version": "4.17.21"
+      "version": "4.17.21",
+      "dev": true
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -9709,6 +9740,7 @@
     },
     "path-is-network-drive": {
       "version": "1.0.10",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -9724,6 +9756,7 @@
     },
     "path-strip-sep": {
       "version": "1.0.7",
+      "dev": true,
       "requires": {
         "tslib": "^2.3.1"
       }
@@ -10115,10 +10148,13 @@
     },
     "ts-toolbelt": {
       "version": "9.6.0",
+      "dev": true,
       "peer": true
     },
     "tslib": {
-      "version": "2.3.1"
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "tslint": {
       "version": "6.1.3",
@@ -10175,7 +10211,8 @@
       "dev": true
     },
     "typedarray-dts": {
-      "version": "1.0.0"
+      "version": "1.0.0",
+      "dev": true
     },
     "typescript": {
       "version": "4.6.3",
@@ -10310,7 +10347,8 @@
       "dev": true
     },
     "yocto-queue": {
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,11 +33,10 @@
   },
   "dependencies": {
     "@rollup/pluginutils": "^4.1.2",
-    "@yarn-tool/resolve-package": "^1.0.40",
     "find-cache-dir": "^3.3.2",
     "fs-extra": "^10.0.0",
     "resolve": "^1.20.0",
-    "tslib": "^2.3.1"
+    "tslib": "^2.4.0"
   },
   "peerDependencies": {
     "rollup": ">=1.26.3",

--- a/src/tslib.ts
+++ b/src/tslib.ts
@@ -5,12 +5,12 @@ export const TSLIB = "tslib";
 export const TSLIB_VIRTUAL = "\0tslib.js";
 export let tslibSource: string;
 export let tslibVersion: string;
+
 try
 {
 	// tslint:disable-next-line:no-string-literal no-var-requires
-	const _ = require("@yarn-tool/resolve-package").resolvePackage('tslib');
-	const tslibPackage = _.pkg;
-	const tslibPath = _.resolveLocation(tslibPackage.module);
+	const tslibPackage = require("tslib/package.json");
+	const tslibPath = require.resolve("tslib/" + tslibPackage.module);
 	tslibSource = readFileSync(tslibPath, "utf8");
 	tslibVersion = tslibPackage.version;
 } catch (e)


### PR DESCRIPTION
## Summary

Resolves #286 in a simpler way by upgrading `tslib` instead of introducing any new deps
- Replaces #289 / #290 

Implements the approach I proposed in https://github.com/ezolenko/rollup-plugin-typescript2/issues/286#issuecomment-1120270016 

## Details

- `tslib` `2.4.0` is forward and backward-compatible with older and newer Node exports mechanisms, so the Node 17 error should no longer be present
  - see its [`package.json`](https://github.com/microsoft/tslib/blob/a7129c7bd500ce378ec19234247f3d0b1635e89d/package.json#L35) after https://github.com/microsoft/tslib/pull/135
    - it has the older `./` and the newer `./*` in its package exports, which should allow for `package.json` to be read in both older and newer implementations

- this allows us to remove the extra dep on `@yarn-tool/resolve-package` as well
  - other than less unnecessary deps being good, `@yarn-tool/resolve-package` is also a not well-documented package with very few users, which does not make for a good security posture for rpt2 (which has historically prioritized supply chain security in other issues around deps (c.f. #80, https://github.com/ezolenko/rollup-plugin-typescript2/pull/293#issuecomment-993918512) or, in particular, its consumers, which there are very many of (in contrast with `@yarn-tool`)
  - per my issue comment https://github.com/ezolenko/rollup-plugin-typescript2/issues/286#issuecomment-1120270016, we could also have avoided the extra dep prior to the `tslib` upgrade by resolving to absolute paths, as Node only does a ["weak" encapsulation](https://nodejs.org/api/packages.html#main-entry-point-export) of relative imports

- test: add a small unit test for `tslib.ts` to ensure that this method works and passes on different Node versions in CI
  - more a smoke test that it runs at all, the testing is additional and a bit duplicative of the source tbh