### PR TITLE
ci: add a lint check to ensure all PRs pass lint too

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -10,8 +10,8 @@ on:
     branches: [ master ]
 
 jobs:
-  build-and-test:
-    name: Build & Test on Node ${{ matrix.node-version }} and ${{ matrix.os }}
+  lint-build-test:
+    name: Lint, Build, Test - Node ${{ matrix.node-version }}, ${{ matrix.os }}
 
     runs-on: ${{ matrix.os }}
     strategy:
@@ -27,6 +27,7 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'npm'
     - run: npm ci
+    - run: npm run lint
     - run: npm run build
     - run: npm run build-self
     - run: npm run build-self


### PR DESCRIPTION
## Summary

Run `npm run lint` in CI

## Details

- rename the job a bit to match, and shrink the name a bit for conciseness as it didn't always fit on screen in the list of checks

- this could be done in a different job as it's not necessarily required for linting to run through the entire matrix, but this is simpler for now as we don't have a further need for separate jobs
  - and no need to re-run install etc, and the tests are fast anyway currently, so no perf need there either
  
## Next Steps

1. Still need to upgrade to `@typescript-eslint` -- this might be good for a community contribution?
1. Could add a formatter like `prettier` as well instead of relying on `editorconfig` etc (a lot of style things are currently missed by `lint`; something I notice in particular as I typically use single quotes and no semi-colons and need to adjust in this codebase)