### PR TITLE
refactor: prefer native methods to lodash where possible

### DIFF
--- a/src/host.ts
+++ b/src/host.ts
@@ -1,6 +1,5 @@
 import { tsModule } from "./tsproxy";
 import * as tsTypes from "typescript";
-import * as _ from "lodash";
 import { normalizePath as normalize } from "@rollup/pluginutils";
 import { TransformerFactoryCreator } from "./ioptions";
 
@@ -44,7 +43,7 @@ export class LanguageServiceHost implements tsTypes.LanguageServiceHost
 	{
 		fileName = normalize(fileName);
 
-		if (_.has(this.snapshots, fileName))
+		if (fileName in this.snapshots)
 			return this.snapshots[fileName];
 
 		const source = tsModule.sys.readFile(fileName);
@@ -136,11 +135,11 @@ export class LanguageServiceHost implements tsTypes.LanguageServiceHost
 		{
 			const factory = creator(this.service);
 			if (factory.before)
-				transformer.before = _.concat(transformer.before!, factory.before);
+				transformer.before = transformer.before!.concat(factory.before);
 			if (factory.after)
-				transformer.after = _.concat(transformer.after!, factory.after);
+				transformer.after = transformer.after!.concat(factory.after);
 			if (factory.afterDeclarations)
-				transformer.afterDeclarations = _.concat(transformer.afterDeclarations!, factory.afterDeclarations);
+				transformer.afterDeclarations = transformer.afterDeclarations!.concat(factory.afterDeclarations);
 		}
 
 		return transformer;

--- a/src/parse-tsconfig.ts
+++ b/src/parse-tsconfig.ts
@@ -27,7 +27,7 @@ export function parseTsConfig(context: IContext, pluginOptions: IOptions)
 			throw new Error(`rpt2: failed to read '${fileName}'`);
 
 		const result = tsModule.parseConfigFileTextToJson(fileName, text);
-		pretty = _.get(result.config, "pretty", pretty);
+		pretty = result.config?.pretty ?? pretty;
 
 		if (result.error !== undefined)
 		{

--- a/src/print-diagnostics.ts
+++ b/src/print-diagnostics.ts
@@ -2,11 +2,10 @@ import { tsModule } from "./tsproxy";
 import { red, white, yellow } from "colors/safe";
 import { IContext } from "./context";
 import { IDiagnostics } from "./tscache";
-import * as _ from "lodash";
 
 export function printDiagnostics(context: IContext, diagnostics: IDiagnostics[], pretty: boolean): void
 {
-	_.each(diagnostics, (diagnostic) =>
+	diagnostics.forEach((diagnostic) =>
 	{
 		let print;
 		let color;


### PR DESCRIPTION
## Summary

Replace most (not all) `lodash` methods with native methods

## Details

- `_.endsWith` -> String.endsWith

- `_.concat` -> Array.concat
- `_.each` -> Array.forEach
- `_.filter` -> Array.filter
- `_.map` -> Array.map
- `_.some` -> Array.some

- `_.has` -> `key in Object`
- `_.defaults` -> Object.assign
- `_.get` -> `?.` and `??` (optional chaining and nullish coalescing)

- refactor: replace fairly complicated `expandIncludeWithDirs` func to just use a few simple `forEach`s
  - not as FP anymore, more imperative, but much simpler to read IMO
- refactor: add a `getDiagnostics` helper to DRY up some code
  - also aids readability IMO

- a few places are still using lodash, but this paves the way toward removing it or replacing it with much smaller individual deps
  - `_.compact` still used because Array.filter heavily complicates the type-checking currently
  - `_.isFunction` still used because while it's a one-liner natively, need to import a function in several places
    - also the package [`lodash.isFunction`](https://www.npmjs.com/package/lodash.isfunction) is lodash v3 and quite [different](https://github.com/lodash/lodash/blob/3.0.9-npm-packages/lodash.isfunction/index.js) from the [v4 implementation](https://github.com/lodash/lodash/blob/2da024c3b4f9947a48517639de7560457cd4ec6c/isFunction.js#L28), so couldn't replace with it unfortunately
  - `_.merge` is a deep merge, so there's no native version of this
    - but we may remove deep merges entirely in the future (as tsconfig doesn't quite perform a deep merge, c.f. https://github.com/ezolenko/rollup-plugin-typescript2/issues/86#issuecomment-1116144443), or could replace this with a smaller `lodash.merge` package or similar

- see also https://github.com/you-dont-need/You-Dont-Need-Lodash-Underscore

## Review Notes

Unit tests still pass, so other than looking equivalent and typing equivalently, usage still works equivalently (caveat though: `tscache` and `index` aren't yet tested)

