### PR TITLE
fix: normalize paths in `get-options-overrides`

### DIFF
--- a/__tests__/get-options-overrides.spec.ts
+++ b/__tests__/get-options-overrides.spec.ts
@@ -11,7 +11,7 @@ import { getOptionsOverrides, createFilter } from "../src/get-options-overrides"
 
 setTypescriptModule(ts);
 
-const local = (x: string) => path.resolve(__dirname, x);
+const local = (x: string) => normalize(path.resolve(__dirname, x));
 const cacheDir = local("__temp/get-options-overrides");
 
 // filter expects an absolute path and resolves include/exclude to process.cwd() by default: https://github.com/ezolenko/rollup-plugin-typescript2/pull/321#discussion_r873077874
@@ -51,7 +51,7 @@ const forcedOptions: ts.CompilerOptions = {
 	noEmit: false,
 	noEmitHelpers: false,
 	noResolve: false,
-	outDir: `${cacheDir}/placeholder`, // TODO: fix get-options-overrides.ts on Windows by normalizing the path: https://github.com/ezolenko/rollup-plugin-typescript2/pull/321#discussion_r869710856
+	outDir: `${cacheDir}/placeholder`,
 };
 
 const defaultPreParsedTsConfig: ts.ParsedCommandLine = {

--- a/src/get-options-overrides.ts
+++ b/src/get-options-overrides.ts
@@ -1,8 +1,8 @@
-import { createFilter as createRollupFilter} from "@rollup/pluginutils";
+import { createFilter as createRollupFilter, normalizePath as normalize } from "@rollup/pluginutils";
 import { tsModule } from "./tsproxy";
 import * as tsTypes from "typescript";
 import { IOptions } from "./ioptions";
-import { join } from "path";
+import * as path from "path";
 import { IContext } from "./context";
 
 export function getOptionsOverrides({ useTsconfigDeclarationDir, cacheRoot }: IOptions, preParsedTsconfig?: tsTypes.ParsedCommandLine): tsTypes.CompilerOptions
@@ -13,7 +13,7 @@ export function getOptionsOverrides({ useTsconfigDeclarationDir, cacheRoot }: IO
 		noResolve: false,
 		noEmit: false,
 		inlineSourceMap: false,
-		outDir: `${cacheRoot}/placeholder`, // need an outdir that is different from source or tsconfig parsing trips up. https://github.com/Microsoft/TypeScript/issues/24715
+		outDir: normalize(`${cacheRoot}/placeholder`), // need an outdir that is different from source or tsconfig parsing trips up. https://github.com/Microsoft/TypeScript/issues/24715
 		moduleResolution: tsModule.ModuleResolutionKind.NodeJs,
 		allowNonTsExtensions: true,
 	};
@@ -42,9 +42,9 @@ function expandIncludeWithDirs(include: string | string[], dirs: string[])
 
 	dirs.forEach(root => {
 		if (include instanceof Array)
-			include.forEach(x => newDirs.push(join(root, x)));
+			include.forEach(x => newDirs.push(normalize(path.join(root, x))));
 		else
-			newDirs.push(join(root, include));
+			newDirs.push(normalize(path.join(root, include)));
 	});
 	return newDirs;
 }


### PR DESCRIPTION
## Summary

`get-options-overrides.ts` had some paths that were not normalized, resulting in mixed separators on Windows in certain cases.
- Fixes https://github.com/ezolenko/rollup-plugin-typescript2/pull/321#discussion_r869710856
- Fixes https://github.com/ezolenko/rollup-plugin-typescript2/pull/329#discussion_r873108879
  - Also follow-up to https://github.com/ezolenko/rollup-plugin-typescript2/pull/329#issuecomment-1138876847

## Details

- the `outDir` was not normalized after the `/placeholder` part was added to `cacheRoot`
  - `cacheRoot` could have `\` directory separators on it on Windows, which caused some tests to fail on Windows before
  - tests have been normalized now too

- `expandIncludeWithDirs` used `path.join` without normalizing after
  - `path.join` uses the OS's native separators (`posix.join` would do POSIX separators only), so when the paths were already normalized and then `path.join`ed, this would cause mixed separators on Windows
  - this fixes the current [CI failure on Windows](https://github.com/ezolenko/rollup-plugin-typescript2/runs/6516149780?check_suite_focus=true) in the `createFilter` tests (`rootDirs` and `projectReferences`, which use `expandIncludeWithDirs`)

## Review Notes

This should just be a bugfix and not breaking, but per the linked discussions, I'm really not sure how these bugs haven't been found yet by consumers -- I'm guessing that TS does normalization on `outDir` (lots of redundant normalization necessary due to ambiguous inputs) and that `rootDirs` and `projectReferences` just aren't used by many Windows users.