### PR TITLE
fix: add `realpath` to host to properly resolve monorepos

### DIFF
--- a/__tests__/host.spec.ts
+++ b/__tests__/host.spec.ts
@@ -61,8 +61,9 @@ test("LanguageServiceHost", async () => {
 	expect(host.readFile(nonExistent)).toBeFalsy();
 	expect(host.readFile(testFile)).toEqual(unaryFunc);
 	expect(host.useCaseSensitiveFileNames()).toBe(process.platform === "linux");
-	expect(host.realpath(testFile)).toEqual(testFile);
-	expect(host.realpath(linkedTestFile)).toEqual(testFile);
+	// test realpath w/ symlinks. this returns a host path, so expect path.normalize()
+	expect(host.realpath(testFile)).toEqual(path.normalize(testFile));
+	expect(host.realpath(linkedTestFile)).toEqual(path.normalize(testFile));
 
 	// test misc functionality
 	expect(host.getCompilationSettings()).toEqual(testOpts);

--- a/src/host.ts
+++ b/src/host.ts
@@ -104,6 +104,11 @@ export class LanguageServiceHost implements tsTypes.LanguageServiceHost
 		return tsModule.sys.fileExists(path);
 	}
 
+	public realpath(path: string): string
+	{
+		return tsModule.sys.realpath!(path); // this exists in the default implementation: https://github.com/microsoft/TypeScript/blob/ab2523bbe0352d4486f67b73473d2143ad64d03d/src/compiler/sys.ts#L1288
+	}
+
 	public getTypeRootsVersion(): number
 	{
 		return 0;


### PR DESCRIPTION
## Summary

Implement `realpath` in `host.ts` to properly resolve symlinks, i.e. for monorepos

While the code for this is tiny, this is a pretty _huge_ bugfix given the number of users that have run into this here and downstream (in `microbundle`, TSDX, etc) -- glad to finally fix such a common error!

## Details

- tested this in a `pnpm` repo with symlinked deps and it worked there, so I believe this fixes all `pnpm` issues
  - it may also fix some Lerna issues if they were due to symlinks, but I didn't check those
  - not sure about others, e.g. Rush, Yarn workspaces, Yarn PnP

- I figured out this was needed by staring at the TS source code and then I found this [line](https://github.com/microsoft/TypeScript/blob/67673f324dd5f9398bb53fd16bf75efd155c32e7/src/compiler/moduleNameResolver.ts#L1412) 
  - it expects `host.realpath` to be implemented for TS's `realPath` to work correctly, otherwise it just returns the path with no transformation (i.e. the path to the symlink instead of the realpath)
    - this is not documented _anywhere_ and we were hitting this when calling `getEmitOutput`, before even using `moduleNameResolver`
  - so I just tried implementing it... and it worked!
  - notably, the other Rollup TS plugins don't implement this either???
    - not sure how they don't error on this??

- See my root cause analysis in https://github.com/ezolenko/rollup-plugin-typescript2/issues/234#issuecomment-1139202740 for (much) more details

## Review Notes

- note that I added a `!` as `realpath` doesn't have to be implemented on `ts.sys`... but it is in the default implementation (see comment)
  - I originally had a ternary with `fs.realpathSync` if it didn't exist but that is literally what the default implementation uses
    - can add this back in the future if it becomes an issue
    
## References

- Fixes #330
- Fixes #234
- ~Possible fix for #254, which mentions `pnpm` symlinks, but haven't tested~
  - **EDIT**: I investigated and responded in https://github.com/ezolenko/rollup-plugin-typescript2/issues/254#issuecomment-1140503934 -- that's actually completely unrelated and `pnpm` and other things were totally red herrings to the root cause
- Possible fix for #214 and #188, which are Lerna repos, but haven't tested
- Possible fix for #274, which mentions "monorepo" and has a similar kind of issue with declaration output as #330, but there is no repro to test against
- ~Also possible fix for #237, which has a workaround and mentions "monorepo", but unsure if related and no repro was provided there~
  - **EDIT**: I investigated a bit more there and responded in https://github.com/ezolenko/rollup-plugin-typescript2/issues/237#issuecomment-1139222519 -- that actually seems to be correct behavior and the "workaround" is the proper solution. Unsure about the second, unrelated feature request/PR that was added but it solved itself
- As a result, this at least partially fixes the common pattern of monorepo / symlink issues in this codebase that I mentioned in https://github.com/ezolenko/rollup-plugin-typescript2/pull/311#issuecomment-1115491161

Possible downstream fixes:
- https://github.com/developit/microbundle/issues/931, which is a Rush monorepo
- https://github.com/jaredpalmer/tsdx/issues/967 and https://github.com/jaredpalmer/tsdx/issues/953, which both use Rush and PNPM
- There's probably more of these that I didn't find in a quick search