### PR TITLE
- partially undoing lodash change

### DIFF
--- a/src/get-options-overrides.ts
+++ b/src/get-options-overrides.ts
@@ -3,6 +3,7 @@ import { tsModule } from "./tsproxy";
 import * as tsTypes from "typescript";
 import { IOptions } from "./ioptions";
 import * as path from "path";
+import * as _ from "lodash";
 import { IContext } from "./context";
 
 export function getOptionsOverrides({ useTsconfigDeclarationDir, cacheRoot }: IOptions, preParsedTsconfig?: tsTypes.ParsedCommandLine): tsTypes.CompilerOptions

--- a/src/index.ts
+++ b/src/index.ts
@@ -303,7 +303,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			if (!parsedConfig.options.declaration)
 				return;
 
-			parsedConfig.fileNames.forEach((name) =>
+			_.each(parsedConfig.fileNames, (name) =>
 			{
 				const key = normalize(name);
 				if (key in declarations)
@@ -370,9 +370,8 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 				}
 			};
 
-			Object.keys(declarations).forEach((key) =>
+			_.each(declarations, ({ type, map }, key) =>
 			{
-				const { type, map } = declarations[key];
 				emitDeclaration(key, ".d.ts", type);
 				emitDeclaration(key, ".d.ts.map", map);
 			});

--- a/src/print-diagnostics.ts
+++ b/src/print-diagnostics.ts
@@ -2,10 +2,11 @@ import { tsModule } from "./tsproxy";
 import { red, white, yellow } from "colors/safe";
 import { IContext } from "./context";
 import { IDiagnostics } from "./tscache";
+import * as _ from "lodash";
 
 export function printDiagnostics(context: IContext, diagnostics: IDiagnostics[], pretty: boolean): void
 {
-	diagnostics.forEach((diagnostic) =>
+	_.each(diagnostics, (diagnostic) =>
 	{
 		let print;
 		let color;

--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -264,7 +264,7 @@ export class TsCache
 		if (this.ambientTypesDirty)
 			this.context.info(yellow("ambient types changed, redoing all semantic diagnostics"));
 
-		_.each(typeNames, (name) => this.typesCache.touch(name));
+		typeNames.forEach(this.typesCache.touch, this.typesCache);
 	}
 
 	private getDiagnostics(type: string, cache: ICache<IDiagnostics[]>, id: string, snapshot: tsTypes.IScriptSnapshot, check: () => tsTypes.Diagnostic[]): IDiagnostics[]

--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -180,13 +180,13 @@ export class TsCache
 
 		if (acyclic)
 		{
-			alg.topsort(this.dependencyTree).forEach(id => cb(id));
+			_.each(alg.topsort(this.dependencyTree), (id: string) => cb(id));
 			return;
 		}
 
 		this.context.info(yellow("import tree has cycles"));
 
-		this.dependencyTree.nodes().forEach(id => cb(id));
+		_.each(this.dependencyTree.nodes(), (id: string) => cb(id));
 	}
 
 	public done()
@@ -264,7 +264,7 @@ export class TsCache
 		if (this.ambientTypesDirty)
 			this.context.info(yellow("ambient types changed, redoing all semantic diagnostics"));
 
-		typeNames.forEach(this.typesCache.touch, this);
+		_.each(typeNames, (name) => this.typesCache.touch(name));
 	}
 
 	private getDiagnostics(type: string, cache: ICache<IDiagnostics[]>, id: string, snapshot: tsTypes.IScriptSnapshot, check: () => tsTypes.Diagnostic[]): IDiagnostics[]
@@ -342,9 +342,8 @@ export class TsCache
 
 		const dependencies = alg.dijkstra(this.dependencyTree, id);
 
-		return Object.keys(dependencies).some(node =>
+		return _.some(dependencies, (dependency, node) =>
 		{
-			const dependency = dependencies[node];
 			if (!node || dependency.distance === Infinity)
 				return false;
 


### PR DESCRIPTION
Partially undoing recent lodash change (#328), `_.each()` semantics is apparently different from `Array.forEach()` -- during the build it created "undefined" folder with bunch of empty files.