### PR TITLE
fix: don't attempt to change declarationMap `sources` when no output

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -337,12 +337,12 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 				// don't mutate the entry because generateBundle gets called multiple times
 				let entryText = entry.text
-				const declarationDir = (_output.file ? dirname(_output.file) : _output.dir) as string;
 				const cachePlaceholder = `${pluginOptions.cacheRoot}/placeholder`
 
-				// modify declaration map sources to correct relative path
-				if (extension === ".d.ts.map")
+				// modify declaration map sources to correct relative path (only if outputting)
+				if (extension === ".d.ts.map" && (_output?.file || _output?.dir))
 				{
+					const declarationDir = (_output.file ? dirname(_output.file) : _output.dir) as string;
 					const parsedText = JSON.parse(entryText) as SourceMap;
 					// invert back to absolute, then make relative to declarationDir
 					parsedText.sources = parsedText.sources.map(source =>


### PR DESCRIPTION
## Summary

Skip transforming declarationMap `sources` when there is no output, i.e. in the case of using rpt2 as a [`configPlugin`](https://rollupjs.org/guide/en/#--configplugin-plugin)
- Fixes #310 

## Details

- when using rpt2 as a `configPlugin`, there is no Rollup `output`, so it will be `undefined`
  - when `declarationMap: true` in `tsconfig`, this block of code is called as a workaround due to the `placeholder` dir we must use for output -- but, in this case, it errors out, since the `declarationDir` is `undefined`
    - `path.relative` needs a `string` as a arg, not `undefined`
    - so skip this transformation entirely when there's no `output`, as it doesn't need to be done in that case anyway
    - this transformation code happens to have been written by me 2 years ago too in #221, so I had fixed one bug with that but created a different bug 😅  (fortunately a smaller one that only I have stumbled upon so far)