### PR TITLE
refactor: invert some conditionals for better readability

### DIFF
--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -70,7 +70,7 @@ export function getAllReferences(importer: string, snapshot: tsTypes.IScriptSnap
 	return _.compact(info.referencedFiles.concat(info.importedFiles).map((reference) =>
 	{
 		const resolved = tsModule.nodeModuleNameResolver(reference.fileName, importer, options, tsModule.sys);
-		return resolved.resolvedModule ? resolved.resolvedModule.resolvedFileName : undefined;
+		return resolved.resolvedModule?.resolvedFileName;
 	}));
 }
 


### PR DESCRIPTION
## Summary

Small refactor to invert some conditionals/`if` statements for better readability
- handful of refactors I'm making as I'm now very familiar with the codebase to make it easier to work with and more approachable to new contributors as well

## Details

- a few `if (cond) { big block } return` could be inverted to `if (!cond) return` then the block un-indented instead
  - generally speaking, this makes it a lot more readable (less indentation, etc) and follows the existing code style in much of the codebase, where it's a few quick one-line ifs and then just the rest of the code

- shorten the resolvedFileName conditional by using optional chaining
  - prefer the simpler `x?.y` over the older `x && x.y` syntax
- add a `resolved` variable for less repetition of the whole statement
- add a comment to the `pathNormalize` line about why it's used in that one place and link to the longer description in the PR as well

- shorten comment about `useTsconfigDeclarationDir` so it doesn't take up so much space or look so important as a result
  - it's easier to read this way and I made the explanation less verbose and quicker to read too
  - already have comments and lines in the codebase longer than 80 chars, so that's not a guideline that's followed anywhere else
- remove the `else` there and just add an early return instead, similar to the inverted conditionals above
  - similarly makes it less unindented, more readable etc
  
## Review Notes

- This is unfortunately going to merge conflict with #334 as one of the conditionals is changed there as well, so I'll need to rebase this once that's fixed

- [Ignoring whitespace changes](https://github.com/ezolenko/rollup-plugin-typescript2/pull/335/files?w=1) makes this PR easier to read