### PR TITLE
fix: use `.d.ts` instead of `.vue.d.ts` for Vue declarations 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -328,7 +328,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 				let fileName = entry.name;
 				if (fileName.includes("?")) // HACK for rollup-plugin-vue, it creates virtual modules in form 'file.vue?rollup-plugin-vue=script.ts'
-					fileName = fileName.split("vue?", 1) + extension;
+					fileName = fileName.split(".vue?", 1) + extension;
 
 				// If 'useTsconfigDeclarationDir' is given in the
 				// plugin options, directly write to the path provided

--- a/src/index.ts
+++ b/src/index.ts
@@ -328,7 +328,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 				let fileName = entry.name;
 				if (fileName.includes("?")) // HACK for rollup-plugin-vue, it creates virtual modules in form 'file.vue?rollup-plugin-vue=script.ts'
-					fileName = fileName.split("?", 1) + extension;
+					fileName = fileName.split("vue?", 1) + extension;
 
 				// If 'useTsconfigDeclarationDir' is given in the
 				// plugin options, directly write to the path provided


### PR DESCRIPTION
## Summary

For the `rollup-plugin-vue` integration, output declarations as `name.d.ts` instead of `name.vue.d.ts`
- Fixes #224 , follow-up to https://github.com/ezolenko/rollup-plugin-typescript2/issues/224#issuecomment-642790321

## Details

- `.vue.d.ts` was recommended by the `rollup-plugin-vue` maintainers in https://github.com/ezolenko/rollup-plugin-typescript2/issues/97#issuecomment-405607066 back when this code was originally written, but apparently it causes problems with some imports according to #224
  - plain `.d.ts` seems to work fine according to users in that issue
    - and plain is the standard in TS too I believe?