### PR TITLE
refactor: sort all top-level imports

### DIFF
--- a/src/check-tsconfig.ts
+++ b/src/check-tsconfig.ts
@@ -1,5 +1,6 @@
-import { tsModule } from "./tsproxy";
 import * as tsTypes from "typescript";
+
+import { tsModule } from "./tsproxy";
 
 export function checkTsConfig(parsedConfig: tsTypes.ParsedCommandLine): void
 {

--- a/src/diagnostics-format-host.ts
+++ b/src/diagnostics-format-host.ts
@@ -1,5 +1,6 @@
 import * as path from "path";
 import * as tsTypes from "typescript";
+
 import { tsModule } from "./tsproxy";
 
 export class FormatHost implements tsTypes.FormatDiagnosticsHost

--- a/src/get-options-overrides.ts
+++ b/src/get-options-overrides.ts
@@ -1,8 +1,9 @@
-import { createFilter as createRollupFilter, normalizePath as normalize } from "@rollup/pluginutils";
-import { tsModule } from "./tsproxy";
-import * as tsTypes from "typescript";
-import { IOptions } from "./ioptions";
 import * as path from "path";
+import * as tsTypes from "typescript";
+import { createFilter as createRollupFilter, normalizePath as normalize } from "@rollup/pluginutils";
+
+import { tsModule } from "./tsproxy";
+import { IOptions } from "./ioptions";
 import { IContext } from "./context";
 
 export function getOptionsOverrides({ useTsconfigDeclarationDir, cacheRoot }: IOptions, preParsedTsconfig?: tsTypes.ParsedCommandLine): tsTypes.CompilerOptions

--- a/src/host.ts
+++ b/src/host.ts
@@ -1,6 +1,7 @@
-import { tsModule } from "./tsproxy";
 import * as tsTypes from "typescript";
 import { normalizePath as normalize } from "@rollup/pluginutils";
+
+import { tsModule } from "./tsproxy";
 import { TransformerFactoryCreator } from "./ioptions";
 
 export class LanguageServiceHost implements tsTypes.LanguageServiceHost

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,22 +1,21 @@
+import { relative, dirname, normalize as pathNormalize, resolve as pathResolve } from "path";
+import * as tsTypes from "typescript";
+import { PluginImpl, PluginContext, InputOptions, OutputOptions, TransformResult, SourceMap, Plugin } from "rollup";
+import { normalizePath as normalize } from "@rollup/pluginutils";
+import * as _ from "lodash";
+import { blue, red, yellow, green } from "colors/safe";
+import * as resolve from "resolve";
+import findCacheDir from "find-cache-dir";
+
 import { RollupContext } from "./rollupcontext";
 import { ConsoleContext, VerbosityLevel } from "./context";
 import { LanguageServiceHost } from "./host";
 import { TsCache, convertDiagnostic, convertEmitOutput, getAllReferences } from "./tscache";
 import { tsModule, setTypescriptModule } from "./tsproxy";
-import * as tsTypes from "typescript";
-import * as resolve from "resolve";
-import * as _ from "lodash";
 import { IOptions } from "./ioptions";
 import { parseTsConfig } from "./parse-tsconfig";
 import { printDiagnostics } from "./print-diagnostics";
 import { TSLIB, TSLIB_VIRTUAL, tslibSource, tslibVersion } from "./tslib";
-import { blue, red, yellow, green } from "colors/safe";
-import { relative, dirname, normalize as pathNormalize, resolve as pathResolve } from "path";
-import { normalizePath as normalize } from "@rollup/pluginutils";
-import findCacheDir from "find-cache-dir";
-
-import { PluginImpl, PluginContext, InputOptions, OutputOptions, TransformResult, SourceMap, Plugin } from "rollup";
-
 import { createFilter } from "./get-options-overrides";
 
 type RPT2Options = Partial<IOptions>;

--- a/src/ioptions.ts
+++ b/src/ioptions.ts
@@ -1,5 +1,6 @@
-import { tsModule } from "./tsproxy";
 import * as tsTypes from "typescript";
+
+import { tsModule } from "./tsproxy";
 
 export interface ICustomTransformer
 {

--- a/src/parse-tsconfig.ts
+++ b/src/parse-tsconfig.ts
@@ -1,11 +1,12 @@
+import { dirname } from "path";
+import * as _ from "lodash";
+
 import { tsModule } from "./tsproxy";
 import { IContext } from "./context";
-import { dirname } from "path";
 import { printDiagnostics } from "./print-diagnostics";
 import { convertDiagnostic } from "./tscache";
 import { getOptionsOverrides } from "./get-options-overrides";
 import { IOptions } from "./ioptions";
-import * as _ from "lodash";
 import { checkTsConfig } from "./check-tsconfig";
 
 export function parseTsConfig(context: IContext, pluginOptions: IOptions)

--- a/src/print-diagnostics.ts
+++ b/src/print-diagnostics.ts
@@ -1,5 +1,6 @@
-import { tsModule } from "./tsproxy";
 import { red, white, yellow } from "colors/safe";
+
+import { tsModule } from "./tsproxy";
 import { IContext } from "./context";
 import { IDiagnostics } from "./tscache";
 

--- a/src/rollingcache.ts
+++ b/src/rollingcache.ts
@@ -1,7 +1,8 @@
-import { ICache } from "./icache";
-import { emptyDirSync, ensureFileSync, readJsonSync, removeSync, writeJsonSync } from "fs-extra";
 import { existsSync, readdirSync, renameSync } from "fs";
+import { emptyDirSync, ensureFileSync, readJsonSync, removeSync, writeJsonSync } from "fs-extra";
 import * as _ from "lodash";
+
+import { ICache } from "./icache";
 
 /**
  * Saves data in new cache folder or reads it from old one.

--- a/src/rollupcontext.ts
+++ b/src/rollupcontext.ts
@@ -1,6 +1,7 @@
-import { IContext, VerbosityLevel } from "./context";
 import * as _ from "lodash";
 import { PluginContext } from "rollup";
+
+import { IContext, VerbosityLevel } from "./context";
 
 export class RollupContext implements IContext
 {

--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -1,13 +1,14 @@
-import { IContext } from "./context";
+import * as tsTypes from "typescript";
+import { emptyDirSync, pathExistsSync, readdirSync, removeSync, statSync } from "fs-extra";
+import * as _ from "lodash";
 import { Graph, alg } from "graphlib";
 import hash from "object-hash";
+import { blue, yellow, green } from "colors/safe";
+
+import { IContext } from "./context";
 import { RollingCache } from "./rollingcache";
 import { ICache } from "./icache";
-import * as _ from "lodash";
 import { tsModule } from "./tsproxy";
-import * as tsTypes from "typescript";
-import { blue, yellow, green } from "colors/safe";
-import { emptyDirSync, pathExistsSync, readdirSync, removeSync, statSync } from "fs-extra";
 import { formatHost } from "./diagnostics-format-host";
 import { NoCache } from "./nocache";
 


### PR DESCRIPTION
## Summary

Sort imports by external deps first, then local/internal deps next (AKA absolute imports first, then relative imports)

## Details

- basically, general format is:
  ```ts
  import x from "external-dep"

  import y from "./internal-dep"
  ```
  - so external deps, new line, then internal/local deps
  - with some further sorting within there, like trying to keep Node built-ins (e.g. `path`) at the top half of externals, then core deps like `typescript`, then any other external deps
    - and similar for internal deps -- core internals at the top half of internals, then any other internal deps
    - just to keep things consistent between files -- makes the top easier to read through when it's similar between files
    - also makes it easier for contributors to understand where to put imports, as there's a sorting already there

- this is how I generally sort my imports and how I wrote most of the unit test suite's imports as well (c.f. #321)

- there is automation for this that we should probably add once TSLint is replaced here; some previous art:
  - https://github.com/trivago/prettier-plugin-sort-imports
  - https://github.com/lydell/eslint-plugin-simple-import-sort/
  - Older:
    - https://github.com/renke/import-sort/tree/master/packages/import-sort-style-module
    - https://github.com/mcdougal/js-isort
    - inspired by Python's [`isort`](https://github.com/PyCQA/isort) ofc