### PR TITLE
optim: don't `getScriptSnapshot` when we already have the snapshot

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -213,7 +213,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 						this.error(red(`failed to transpile '${id}'`));
 				}
 
-				const references = getAllReferences(id, servicesHost.getScriptSnapshot(id), parsedConfig.options);
+				const references = getAllReferences(id, snapshot, parsedConfig.options);
 				return convertEmitOutput(output, references);
 			});
 


### PR DESCRIPTION
## Summary

Tiny one-line optimization: `getScriptSnapshot` was called when we already have the snapshot

## Details

- the snapshot is set above, so no need to get it
- also the snapshot from above is used below already, so this doesn't seem to be intentional
  - it originates from https://github.com/ezolenko/rollup-plugin-typescript2/commit/2d330640316894752bae5ae64d94bc90652e4564#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R197 which similarly doesn't seem intentional