### PR TITLE
fix: set `noErrors = false` when there are `compilerOptions` errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,6 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 	if (!pluginOptions.typescript) {
 		pluginOptions.typescript = require("typescript");
 	}
-
 	setTypescriptModule(pluginOptions.typescript);
 
 	const self: Plugin & { _ongenerate: () => void, _onwrite: (this: PluginContext, _output: OutputOptions) => void } = {
@@ -122,8 +121,12 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			servicesHost.setLanguageService(service);
 
 			// printing compiler option errors
-			if (pluginOptions.check)
-				printDiagnostics(context, convertDiagnostic("options", service.getCompilerOptionsDiagnostics()), parsedConfig.options.pretty === true);
+			if (pluginOptions.check) {
+				const diagnostics = convertDiagnostic("options", service.getCompilerOptionsDiagnostics());
+				printDiagnostics(context, diagnostics, parsedConfig.options.pretty === true);
+				if (diagnostics.length > 0)
+					noErrors = false;
+			}
 
 			if (pluginOptions.clean)
 				cache().clean();


### PR DESCRIPTION
## Summary

Set `noErrors = false` when checking `compilerOptions` errors as well

## Details

- previously, while errors would be printed, the flag for `noErrors` was not set to `false`, and so there would be no yellow warning about errors
  - this is mostly just fixing asymmetric UX, but personally, I actually have missed this error before myself, so maybe this will help alleviate that kind of situation