### PR TITLE
refactor: split out a common `typecheckFile` func

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import * as resolve from "resolve";
 import findCacheDir from "find-cache-dir";
 
 import { RollupContext } from "./rollupcontext";
-import { ConsoleContext, VerbosityLevel } from "./context";
+import { ConsoleContext, IContext, VerbosityLevel } from "./context";
 import { LanguageServiceHost } from "./host";
 import { TsCache, convertDiagnostic, convertEmitOutput, getAllReferences } from "./tscache";
 import { tsModule, setTypescriptModule } from "./tsproxy";
@@ -54,6 +54,15 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 		{
 			return service.getSemanticDiagnostics(id);
 		}));
+	}
+
+	const typecheckFile = (id: string, snapshot: tsTypes.IScriptSnapshot, context: IContext) =>
+	{
+			const diagnostics = getDiagnostics(id, snapshot);
+			printDiagnostics(context, diagnostics, parsedConfig.options.pretty === true);
+
+			if (diagnostics.length > 0)
+				noErrors = false;
 	}
 
 	const pluginOptions: IOptions = Object.assign({},
@@ -201,11 +210,8 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 				if (output.emitSkipped)
 				{
-					noErrors = false;
-
 					// always checking on fatal errors, even if options.check is set to false
-					const diagnostics = getDiagnostics(id, snapshot);
-					printDiagnostics(contextWrapper, diagnostics, parsedConfig.options.pretty === true);
+					typecheckFile(id, snapshot, contextWrapper);
 
 					// since no output was generated, aborting compilation
 					cache().done();
@@ -218,13 +224,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			});
 
 			if (pluginOptions.check)
-			{
-				const diagnostics = getDiagnostics(id, snapshot);
-				if (diagnostics.length > 0)
-					noErrors = false;
-
-				printDiagnostics(contextWrapper, diagnostics, parsedConfig.options.pretty === true);
-			}
+				typecheckFile(id, snapshot, contextWrapper);
 
 			if (!result)
 				return undefined;
@@ -277,11 +277,8 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 						return;
 
 					const snapshot = servicesHost.getScriptSnapshot(id);
-					if (!snapshot)
-						return;
-
-					const diagnostics = getDiagnostics(id, snapshot);
-					printDiagnostics(context, diagnostics, parsedConfig.options.pretty === true);
+					if (snapshot)
+						typecheckFile(id, snapshot, context);
 				});
 			}
 
@@ -289,7 +286,6 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 				context.info(yellow("there were errors or warnings."));
 
 			cache().done();
-
 			generateRound++;
 		},
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,10 +56,10 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 		}));
 	}
 
-	const typecheckFile = (id: string, snapshot: tsTypes.IScriptSnapshot, context: IContext) =>
+	const typecheckFile = (id: string, snapshot: tsTypes.IScriptSnapshot, tcContext: IContext) =>
 	{
 			const diagnostics = getDiagnostics(id, snapshot);
-			printDiagnostics(context, diagnostics, parsedConfig.options.pretty === true);
+			printDiagnostics(tcContext, diagnostics, parsedConfig.options.pretty === true);
 
 			if (diagnostics.length > 0)
 				noErrors = false;


### PR DESCRIPTION
## Summary

Split out a common `typecheckFile` function used in 3+ places to DRY up more code

## Details

- this is used in 3 places and going to be more for the code I'm adding to fix type-only imports in #345 (and probably more type-only PRs in the future)
  - so DRY it up and standardize the functionality too
    - some places had `noErrors = false` in one place while others had it in another
    - same for `printDiagnostics`
    - but the ordering actually doesn't matter, so just keep it consistent and the same
      - and then can split a common function that does both out

- technically, now `getDiagnostics` (from #328) is now _only_ used in `typecheckFile`, so I could combine the two together, but I'm refactoring that one up a little
  - but this a good, small example of how refactoring one part of a codebase can make it easier to identify more similar pieces and then refactor even more