### PR TITLE
fix: type-check `include`d files missed by `transform` (type-only files)

### DIFF
--- a/__tests__/integration/errors.spec.ts
+++ b/__tests__/integration/errors.spec.ts
@@ -1,4 +1,5 @@
 import { jest, afterAll, test, expect } from "@jest/globals";
+import { Mock } from "jest-mock"
 import * as path from "path";
 import { normalizePath as normalize } from "@rollup/pluginutils";
 import * as fs from "fs-extra";
@@ -12,7 +13,6 @@ jest.setTimeout(15000);
 
 const local = (x: string) => path.resolve(__dirname, x);
 const cacheRoot = local("__temp/errors/rpt2-cache"); // don't use the one in node_modules
-const onwarn = jest.fn();
 
 afterAll(async () => {
   // workaround: there seems to be some race condition causing fs.remove to fail, so give it a sec first (c.f. https://github.com/jprichardson/node-fs-extra/issues/532)
@@ -20,7 +20,7 @@ afterAll(async () => {
   await fs.remove(cacheRoot);
 });
 
-async function genBundle(relInput: string, extraOpts?: RPT2Options) {
+async function genBundle(relInput: string, extraOpts?: RPT2Options, onwarn?: Mock) {
   const input = normalize(local(`fixtures/errors/${relInput}`));
   return helpers.genBundle({
     input,
@@ -43,9 +43,10 @@ test("integration - semantic error", async () => {
 });
 
 test("integration - semantic error - abortOnError: false / check: false", async () => {
+  const onwarn = jest.fn();
   // either warning or not type-checking should result in the same bundle
-  const { output } = await genBundle("semantic.ts", { abortOnError: false });
-  const { output: output2 } = await genBundle("semantic.ts", { check: false });
+  const { output } = await genBundle("semantic.ts", { abortOnError: false }, onwarn);
+  const { output: output2 } = await genBundle("semantic.ts", { check: false }, onwarn);
   expect(output).toEqual(output2);
 
   expect(output[0].fileName).toEqual("index.js");
@@ -60,7 +61,38 @@ test("integration - syntax error", () => {
 });
 
 test("integration - syntax error - abortOnError: false / check: false", () => {
+  const onwarn = jest.fn();
   const err = "Unexpected token (Note that you need plugins to import files that are not JavaScript)";
-  expect(genBundle("syntax.ts", { abortOnError: false })).rejects.toThrow(err);
-  expect(genBundle("syntax.ts", { check: false })).rejects.toThrow(err);
+  expect(genBundle("syntax.ts", { abortOnError: false }, onwarn)).rejects.toThrow(err);
+  expect(genBundle("syntax.ts", { check: false }, onwarn)).rejects.toThrow(err);
+});
+
+const typeOnlyIncludes = ["**/import-type-error.ts", "**/type-only-import-with-error.ts"];
+
+test("integration - type-only import error", () => {
+  expect(genBundle("import-type-error.ts", {
+    include: typeOnlyIncludes,
+  })).rejects.toThrow("Property 'nonexistent' does not exist on type 'someObj'.");
+});
+
+test("integration - type-only import error - abortOnError: false / check: false", async () => {
+  const onwarn = jest.fn();
+  // either warning or not type-checking should result in the same bundle
+  const { output } = await genBundle("import-type-error.ts", {
+    include: typeOnlyIncludes,
+    abortOnError: false,
+  }, onwarn);
+  const { output: output2 } = await genBundle("import-type-error.ts", {
+    include: typeOnlyIncludes,
+    check: false,
+  }, onwarn);
+  expect(output).toEqual(output2);
+
+  expect(output[0].fileName).toEqual("index.js");
+  expect(output[1].fileName).toEqual("import-type-error.d.ts");
+  expect(output[2].fileName).toEqual("import-type-error.d.ts.map");
+  expect(output[3].fileName).toEqual("type-only-import-with-error.d.ts");
+  expect(output[4].fileName).toEqual("type-only-import-with-error.d.ts.map");
+  expect(output.length).toEqual(5); // no other files
+  expect(onwarn).toBeCalledTimes(1);
 });

--- a/__tests__/integration/fixtures/errors/import-type-error.ts
+++ b/__tests__/integration/fixtures/errors/import-type-error.ts
@@ -1,0 +1,8 @@
+// this file has no errors itself; it is used an entry file to test an error in a type-only import
+
+export type { typeError } from "./type-only-import-with-error";
+
+// some code so this file isn't empty
+export function sum(a: number, b: number) {
+  return a + b;
+}

--- a/__tests__/integration/fixtures/errors/type-only-import-with-error.ts
+++ b/__tests__/integration/fixtures/errors/type-only-import-with-error.ts
@@ -1,0 +1,2 @@
+type someObj = {};
+export type typeError = someObj['nonexistent'];

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,6 +287,23 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 				});
 			}
 
+			// type-check missed files as well
+			parsedConfig.fileNames.forEach((name) =>
+			{
+				if (!pluginOptions.check)
+					return;
+
+				const key = normalize(name);
+				if (key in declarations || !filter(key)) // don't duplicate if it's already been transformed
+					return;
+
+				context.debug(() => `type-checking missed '${key}'`);
+
+				const snapshot = servicesHost.getScriptSnapshot(key);
+				if (snapshot)
+					typecheckFile(key, snapshot, context);
+			});
+
 			if (!watchMode && !noErrors)
 				context.info(yellow("there were errors or warnings."));
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -292,6 +292,8 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 				});
 			}
 
+			const contextWrapper = new RollupContext(pluginOptions.verbosity, pluginOptions.abortOnError, this, "rpt2: ");
+
 			// type-check missed files as well
 			parsedConfig.fileNames.forEach((name) =>
 			{
@@ -303,7 +305,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 				const snapshot = servicesHost.getScriptSnapshot(key);
 				if (snapshot)
-					typecheckFile(key, snapshot, context);
+					typecheckFile(key, snapshot, contextWrapper);
 			});
 
 			buildDone();

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,13 +56,13 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 	const typecheckFile = (id: string, snapshot: tsTypes.IScriptSnapshot, tcContext: IContext) =>
 	{
+			checkedFiles.add(id); // must come before print, as that could bail
+
 			const diagnostics = getDiagnostics(id, snapshot);
 			printDiagnostics(tcContext, diagnostics, parsedConfig.options.pretty !== false);
 
 			if (diagnostics.length > 0)
 				noErrors = false;
-
-			checkedFiles.add(id);
 	}
 
 	const pluginOptions: IOptions = Object.assign({},


### PR DESCRIPTION
## Summary

Type-check some type-only files that were missed in the `transform` hook but are in `parsedConfig.fileNames`
- Fixes #298 (which uses `include` globs)
- Fixes the latter half of #254 (which uses `include` globs)
- Partial workaround for #7, but not complete (see details below)
- Similarly partially fixes some things mentioned in #211, but does not _truly_/completely fix it as it uses `files` (see details below)
  - See my root cause analysis in https://github.com/ezolenko/rollup-plugin-typescript2/issues/298#issuecomment-1146658442 for how I plan to fix that
- Partially fixes the most common issue that I mentioned in https://github.com/ezolenko/rollup-plugin-typescript2/pull/311#issuecomment-1115491161, type-only imports

## Details

- type-only files never get processed by Rollup as their imports are elided/removed by TS in the resulting compiled JS file
  - so, as a workaround, make sure that all files in the `tsconfig` `include` (i.e. in `parsedConfig.fileNames`) are also type-checked
    - note that this will not catch _all_ type-only imports, in particular if one is using `tsconfig` `files` as in #211 (or in general _not_ using glob patterns in `include`) -- this is just a workaround, that requires a separate fix
  - we do the same process for generating declarations for "missed" files right now [in `_onwrite`](https://github.com/ezolenko/rollup-plugin-typescript2/blob/44116044750b01c3b0d612e36f453cc8e64f79b4/src/index.ts#L304), so basically do the same thing but for type-checking in ~`_ongenerate`~ **EDIT**: moved to [`buildEnd`](https://rollupjs.org/guide/en/#buildend) (see below)

(_Note_: _Technically_ speaking, there could be full TS files (i.e. _not_ type-only) that are in the `include` and weren't transformed. These would basically be independent TS files not part of the bundle that the user wanted type-checking and declarations for (as we _already_ generate declarations for those files))

For more details, see my root cause analysis in https://github.com/ezolenko/rollup-plugin-typescript2/issues/298#issuecomment-1146658442

## Review Notes

- ~This is built on top of #344, please merge that first. Marked this as a draft for now~
  - **EDIT**: rebased on top now that it was merged
- ~I'm using the `declarations` dict as a way to detect if a file has already run through the `transform` so as not to duplicate type-checking (both for performance and to not duplicate error messages)~. ~I'm not sure if this is optimal though, I merely copied `_onwrite`'s missed declaration check~.
  - **EDIT**: nvm, that wouldn't work given that you can type-check without outputting any declarations, created a new `Set` to track this instead  
  - ~This also runs for each Rollup `output`, so de-duping is pretty important in that sense too~
    - **EDIT**: moved to the `buildEnd` hook instead, so it doesn't run for each `output` anymore (and it doesn't generate any output files, unlike the missed declarations, so `buildEnd` is a more correct place for it as well)
   
    
- This exits successfully with zero on a type-error, while `tsc` will exit non-zero and not emit by default. `emitSkipped` is `false` too during the declaration output, despite the type-check error.
  - I could exit out with `this.error` in this case as well, but would have to be a different error message
 
## Misc

Could the `walkTree` call be moved into `buildEnd` as well? That seems like it might be a better place for it, the `!noErrors` output, and maybe `cache.done()` too, but I don't know if there was a reason for putting it in `_ongenerate`.