### PR TITLE
clean: remove redundant `allImportedFiles` check in `_onwrite`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -303,11 +303,6 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 				const key = normalize(name);
 				if (key in declarations)
 					return;
-				if (!allImportedFiles.has(key))
-				{
-					context.debug(() => `skipping declarations for unused '${key}'`);
-					return;
-				}
 
 				context.debug(() => `generating missed declarations for '${key}'`);
 				const output = service.getEmitOutput(key, true);


### PR DESCRIPTION
## Summary

Remove an old, redundant check against `allImportedFiles` that is actually dead code

## Details

- this checks if any of the files in `parsedConfig.fileNames` are _not_ in `allImportedFiles`, but all the files in `parsedConfig.fileNames` are explicitly added in the `options` hook on [line 98](https://github.com/ezolenko/rollup-plugin-typescript2/blob/44116044750b01c3b0d612e36f453cc8e64f79b4/src/index.ts#L98)
  - so this is redundant / dead code; the check will never be true

- this can be considered a remnant of an old bug as an old commit fixed a bug with `allImportedFiles` after it was released: #176