### PR TITLE
fix: `filter` "missed" declarations as well

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -301,7 +301,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			parsedConfig.fileNames.forEach((name) =>
 			{
 				const key = normalize(name);
-				if (key in declarations)
+				if (key in declarations || !filter(key))
 					return;
 				if (!allImportedFiles.has(key))
 				{


### PR DESCRIPTION
## Summary

Only output declarations for files that pass the `filter` check so there isn't a mismatch between JS being `exclude`d, but DTS declarations still being output.
- Fixes #225 
- Fixes #280
- Fixes the pattern of bugs causing confusion around plugin `include` / `exclude` vs. `tsconfig` `include` / `exclude` that I mentioned in https://github.com/ezolenko/rollup-plugin-typescript2/pull/311#issuecomment-1145551324

## Details

- these should run through the same `filter` as runs in `transform` etc
  - prior to this, the plugin `exclude` would filter files in `transform`, meaning no JS would be output for them, but would still output declarations for these very same files that no JS was produced for
    - (this would only happen if one were using an `include` glob or something that made the file appear twice, i.e. once by Rollup in `transform` and once in `parsedConfig.fileNames`)
  - this change makes it so the plugin `exclude` affects both JS and DTS output equivalently
    - it was very confusing when it didn't, and users relied on setting different `tsconfig` `exclude`s to workaround this (as a `tsconfig` `exclude` would make the file not appear in `parsedConfig.fileNames`)