### PR TITLE
refactor: invert another if for readabilty -- in `get-options-overrides`

### DIFF
--- a/src/get-options-overrides.ts
+++ b/src/get-options-overrides.ts
@@ -20,20 +20,20 @@ export function getOptionsOverrides({ useTsconfigDeclarationDir, cacheRoot }: IO
 		allowNonTsExtensions: true,
 	};
 
-	if (preParsedTsconfig)
-	{
-		if (preParsedTsconfig.options.module === undefined)
-			overrides.module = tsModule.ModuleKind.ES2015;
+	if (!preParsedTsconfig)
+		return overrides;
 
-		// only set declarationDir if useTsconfigDeclarationDir is enabled
-		if (!useTsconfigDeclarationDir)
-			overrides.declarationDir = undefined;
+	if (preParsedTsconfig.options.module === undefined)
+		overrides.module = tsModule.ModuleKind.ES2015;
 
-		// unsetting sourceRoot if sourceMap is not enabled (in case original tsconfig had inlineSourceMap set that is being unset and would cause TS5051)
-		const sourceMap = preParsedTsconfig.options.sourceMap;
-		if (!sourceMap)
-			overrides.sourceRoot = undefined;
-	}
+	// only set declarationDir if useTsconfigDeclarationDir is enabled
+	if (!useTsconfigDeclarationDir)
+		overrides.declarationDir = undefined;
+
+	// unsetting sourceRoot if sourceMap is not enabled (in case original tsconfig had inlineSourceMap set that is being unset and would cause TS5051)
+	const sourceMap = preParsedTsconfig.options.sourceMap;
+	if (!sourceMap)
+		overrides.sourceRoot = undefined;
 
 	return overrides;
 }


### PR DESCRIPTION
## Summary

Invert an `if` conditional in `get-options-overrides` for readability
- Basically, a follow-up to #335 

## Details

- my previous commit was mostly focused on `index.ts`, this one is for `get-options-overrides` -- in general, I'm just trying to old code more readable as I come across and then realize that the code can be re-written better, or, in this case, a conditional inverted

## Review Notes

This one's not a big improvement either way and not a complete inversion (it's just an early return of the same final return), so also feel free to reject this. I don't feel strongly about it, but figured I might as well rewrite it to follow the same kind of style found elsewhere