### PR TITLE
github: add more environment details to `envinfo`

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -36,7 +36,7 @@
 <!--
   PLEASE RUN THIS COMMAND INSIDE YOUR PROJECT:
 
-  npx envinfo --npmPackages typescript,rollup,rollup-plugin-typescript2
+  npx envinfo --npmPackages typescript,rollup,rollup-plugin-typescript2 --npmGlobalPackages typescript --system os,cpu --binaries node,yarn,npm
 
   AND PASTE ITS CONTENTS BELOW INSIDE THE CODE SNIPPET vvvvvvvvv
 -->


### PR DESCRIPTION
## Summary

Add global TS version, OS, Node, and package manager details to `envinfo` command in the issue template

## Details

- add global version of TS as well
  - with some frequency, people report not having the same issue with `tsc`, and in some cases, that's because they're using their globally installed version of `tsc`, which is at a different version than their project's `tsc` (e.g. #223)
    - this will help guard against that

- add OS and CPU details
  - OS bc non-POSIX [path separator issues](https://github.com/ezolenko/rollup-plugin-typescript2/labels/topic%3A%20OS%20separators) with Windows are somewhat common
  - CPU in case certain architecture may have an impact, e.g. new Apple ARM Silicon in Mac M1/M2 etc
    - it really shouldn't as this is mostly a high-level library, but some of the lower level functionality of TS and all the FS details _could_ potentially have an impact

- add Node, Yarn, and NPM versions
  - since sometimes it is an issue with the Node version or due to the specific package manager
    - e.g. Yarn workspaces, Lerna, `pnpm` symlinks etc have [caused issues before](https://github.com/ezolenko/rollup-plugin-typescript2/labels/topic%3A%20monorepo%20%2F%20symlinks)
  - that being said, this command won't tell us _which_ of the package managers the user is using, just all the installed ones' versions
  - also wanted to add `pnpm` but it is not yet supported by `envinfo`
    - there has been a PR (https://github.com/tabrindle/envinfo/pull/224) out for it for a while, but hasn't been merged by the creator 😕 