### PR TITLE
github: add a reproduction environment to the issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -16,7 +16,7 @@
       Rollup plugin order matters, so if there is a mismatch here, that could be the cause of your issue.
     -->
 
-1. Can you create a [minimal example](https://stackoverflow.com/help/minimal-reproducible-example) that reproduces this behavior?
+1. Can you create a [minimal example](https://stackoverflow.com/help/minimal-reproducible-example) that reproduces this behavior? Preferably, use [this environment](https://stackblitz.com/edit/rpt2-repro) for your reproduction
     <!--
       Minimal reproductions help us find the root cause of an issue much more expediently than trying to interpret and disentangle a complicated repo.
       The process of creating a minimal reproduction also often helps users find a misconfiguration in their code.


### PR DESCRIPTION
## Summary

Add a repro env to the issue template to get people to make more repros!
- Should hopefully help solve one of the patterns of lack of repros I noticed in https://github.com/ezolenko/rollup-plugin-typescript2/pull/311#issuecomment-1115491161

## Details

- this should help make reproductions easier as it gives a quick starting point requiring no boilerplate and is easily accessible from a browser too

- decided to go with StackBlitz over CodeSandbox and repl.it as it's [WebContainer tech](https://blog.stackblitz.com/posts/introducing-webcontainers/) allows for running Node projects entirely _inside_ the browser (via WebAssembly)
  - meaning that unlike CodeSandbox and repl.it, their platform doesn't need to spin up and connect to a container on the backend
  - so it's much more efficient, performant, and cost-effective
  - and, importantly, it means you don't need an account to get started with a Node project; you only need an account to save your work etc
    - this makes a noticeable UX difference, since user funnels generally decrease the more steps you take (especially a larger one like creating an account)
      - and we want reproductions to be as easy as possible to create (so that people actually create them), so optimizing this flow is important
  - that being said, [CodeSandbox](https://github.com/codesandbox) and [repl.it](https://github.com/replit) have much stronger OSS presences and have open-sourced most of their core technology
    - and [Rollup](https://github.com/rollup/rollup/blame/0ab16cc04b7d6dfe5bd14340ba7448085a379e25/.github/ISSUE_TEMPLATE/bug.yaml#L43) and [`rollup/plugins`](https://github.com/rollup/plugins/blame/36de7cc9c3915667bc0dd203ee7b139da8858959/.github/ISSUE_TEMPLATE/BUG.md#L32) use repl.it for reproductions: https://replit.com/@rollup/rollup-plugin-repro
    - so wanted to use those, but the UX difference was pretty significant
    - repl.it also didn't have as good a DX IMO

- StackBlitz: https://stackblitz.com/edit/rpt2-repro
- GitHub: https://github.com/agilgur5/rpt2-repro
  - Note that I added a `README` with directions there as well as in the `index.ts` file 🙂 

## References

Have already made several reproductions of issues using this environment as well, so can confirm that it works well!
- https://github.com/ezolenko/rollup-plugin-typescript2/issues/306#issuecomment-1150412023
- https://github.com/ezolenko/rollup-plugin-typescript2/issues/305#issuecomment-1150424225
- https://github.com/ezolenko/rollup-plugin-typescript2/issues/297#issuecomment-1150293614
- https://github.com/ezolenko/rollup-plugin-typescript2/issues/272#issuecomment-1150432231
- https://github.com/ezolenko/rollup-plugin-typescript2/issues/247#issuecomment-1150499366
- https://github.com/ezolenko/rollup-plugin-typescript2/issues/223#issuecomment-1150563837