### PR TITLE
refactor(cache): simplify condition w/ optional chaining

### DIFF
--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -132,8 +132,9 @@ export class TsCache
 		this.dependencyTree = new Graph({ directed: true });
 		this.dependencyTree.setDefaultNodeLabel((_node: string) => ({ dirty: false }));
 
-		const automaticTypes = tsModule.getAutomaticTypeDirectiveNames(options, tsModule.sys).map((entry) => tsModule.resolveTypeReferenceDirective(entry, undefined, options, tsModule.sys))
-			.filter((entry) => entry.resolvedTypeReferenceDirective && entry.resolvedTypeReferenceDirective.resolvedFileName)
+		const automaticTypes = tsModule.getAutomaticTypeDirectiveNames(options, tsModule.sys)
+			.map((entry) => tsModule.resolveTypeReferenceDirective(entry, undefined, options, tsModule.sys))
+			.filter((entry) => entry.resolvedTypeReferenceDirective?.resolvedFileName)
 			.map((entry) => entry.resolvedTypeReferenceDirective!.resolvedFileName!);
 
 		this.ambientTypes = rootFilenames.filter(file => file.endsWith(".d.ts"))


### PR DESCRIPTION
## Summary

Simplify a conditional in `tscache.ts` by using optional chaining

## Details

- as I've done in other places (e.g. #335), simplify a condition by using optional chaining syntax (over the previously necessary syntax with `&&` etc)

- also add a new line to the first `.map` here
  - for style consistency and because this is a super long line
  - this wasn't possible before the lodash refactor (#328) because it was all one big single statement in the chain