### PR TITLE
docs(cache): add/change some comments for clarity

### DIFF
--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -313,8 +313,10 @@ export class TsCache
 		}
 		else
 		{
+			// this is an invariant, it should never happen: cacheDir should only not exist when noCache
 			if (this.cacheDir === undefined)
 				throw new Error(`this.cacheDir undefined`);
+
 			this.codeCache = new RollingCache<ICode>(`${this.cacheDir}/code`, true);
 			this.typesCache = new RollingCache<string>(`${this.cacheDir}/types`, true);
 			this.syntacticDiagnosticsCache = new RollingCache<IDiagnostics[]>(`${this.cacheDir}/syntacticDiagnostics`, true);
@@ -327,7 +329,7 @@ export class TsCache
 		this.dependencyTree.setNode(id, { dirty: true });
 	}
 
-	// returns true if node or any of its imports or any of global types changed
+	/** @returns true if node, any of its imports, or any ambient types changed */
 	private isDirty(id: string, checkImports: boolean): boolean
 	{
 		const label = this.dependencyTree.node(id) as INodeLabel;


### PR DESCRIPTION
## Summary

- Modify `isDirty` comment to use typedoc
- Add a comment to specify that a condition is an invariant in `init`

## Details

- use typedoc for `isDirty` comment so that it actually appears in IDEs etc
  - and use [`@returns`](https://typedoc.org/guides/doccomments/#%40return(s)) typedoc annotation for better specification
  - modify the comment a little for better grammar: 3 "or"s and no commas -> 1 "or" and commas
  - use more accurate terminology: "global types" -> "ambient types"
    - that's also more consistent in this codebase itself, where there's a legit function named `checkAmbientTypes`

- in `init`, specify that the `RollingCache` error should never actually happen
  - I was a bit confused by when this would happen, then checked the constructor, and the answer is basically never: it's an invariant / redundant error-check
  - also add a new line for style consistency