### PR TITLE
refactor(cache): split a `getCached` function out

### DIFF
--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -200,37 +200,8 @@ export class TsCache
 
 	public getCompiled(id: string, snapshot: tsTypes.IScriptSnapshot, transform: () => ICode | undefined): ICode | undefined
 	{
-		if (this.noCache)
-		{
-			this.context.info(`${blue("transpiling")} '${id}'`);
-			this.markAsDirty(id);
-			return transform();
-		}
-
-		const hash = this.createHash(id, snapshot);
-
 		this.context.info(`${blue("transpiling")} '${id}'`);
-		this.context.debug(`    cache: '${this.codeCache.path(hash)}'`);
-
-		if (this.codeCache.exists(hash) && !this.isDirty(id, false))
-		{
-			this.context.debug(green("    cache hit"));
-			const data = this.codeCache.read(hash);
-			if (data)
-			{
-				this.codeCache.write(hash, data);
-				return data;
-			}
-			else
-				this.context.warn(yellow("    cache broken, discarding"));
-		}
-
-		this.context.debug(yellow("    cache miss"));
-
-		const transformedData = transform();
-		this.codeCache.write(hash, transformedData);
-		this.markAsDirty(id);
-		return transformedData;
+		return this.getCached(this.codeCache, id, snapshot, false, transform);
 	}
 
 	public getSyntacticDiagnostics(id: string, snapshot: tsTypes.IScriptSnapshot, check: () => tsTypes.Diagnostic[]): IDiagnostics[]
@@ -269,17 +240,18 @@ export class TsCache
 
 	private getDiagnostics(type: string, cache: ICache<IDiagnostics[]>, id: string, snapshot: tsTypes.IScriptSnapshot, check: () => tsTypes.Diagnostic[]): IDiagnostics[]
 	{
+		return this.getCached(cache, id, snapshot, true, () => convertDiagnostic(type, check()));
+	}
+
+	private getCached<CacheType>(cache: ICache<CacheType>, id: string, snapshot: tsTypes.IScriptSnapshot, checkImports: boolean, convert: () => CacheType): CacheType
+	{
 		if (this.noCache)
-		{
-			this.markAsDirty(id);
-			return convertDiagnostic(type, check());
-		}
+			return convert();
 
 		const hash = this.createHash(id, snapshot);
-
 		this.context.debug(`    cache: '${cache.path(hash)}'`);
 
-		if (cache.exists(hash) && !this.isDirty(id, true))
+		if (cache.exists(hash) && !this.isDirty(id, checkImports))
 		{
 			this.context.debug(green("    cache hit"));
 
@@ -295,7 +267,7 @@ export class TsCache
 
 		this.context.debug(yellow("    cache miss"));
 
-		const convertedData = convertDiagnostic(type, check());
+		const convertedData = convert();
 		cache.write(hash, convertedData);
 		this.markAsDirty(id);
 		return convertedData;


### PR DESCRIPTION
## Summary

Decent size simplification in `tscache` so that `getDiagnostics` and `getCompiled` call a common `getCached` function, which is just a tiny refactor of the code that `getDiagnostics` already had.

## Details

- basically, refactor the `getDiagnostics` a tiny bit to also handle what the `getCompiled` function needs
  - then just call `getCached` from both instead
  - `getDiagnostics` and `getCompiled` were near identical except for the cache they used and `checkImports`, which are both parameters now
    - `getCompiled` also had a logging statement (called in both `noCache` and w/ cache branches), which was moved to before the call to `getCompiled` instead
    - the `type` param was composed into another function in `getDiagnostics` before the call too `getCached` now
  - this simplifies all the cache code to one main function now

- remove the `markAsDirty` call under `noCache`, as well, "dirty" has no meaning for `noCache` anyway
  - this simplifies that one `if` statement now too
  
## References

- Note that `checkImports` is actually buggy per my investigation in https://github.com/ezolenko/rollup-plugin-typescript2/issues/292#issuecomment-1152951087 
  - I may end up removing it entirely as such, or at least setting it to `true` when `declaration` is `true` in `getCompiled`
- This was one of the bigger refactors that became easier to do once I completed other refactors (and got more familiar with this portion of the codebase) like #358 etc
  - Still working on 1-3 more refactors of this portion of the codebase, which are all simplifications