### PR TITLE
docs(cache): add a typedoc `@returns` to `createHash`

### DIFF
--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -360,6 +360,7 @@ export class TsCache
 		});
 	}
 
+	/** @returns an FS-safe hash string for use as a path to the cached content */
 	private createHash(id: string, snapshot: tsTypes.IScriptSnapshot)
 	{
 		const data = snapshot.getText(0, snapshot.getLength());


### PR DESCRIPTION
## Summary

Add a `/** @returns */` typedoc comment to `createHash` to explicitly mention that it has to be FS-safe
- Follow-up to https://github.com/ezolenko/rollup-plugin-typescript2/pull/355#issuecomment-1155333976

## Details

- per follow-up comments, this has to be FS-safe, so I thought it would be good to explicitly mention that somewhere