### PR TITLE
refactor: use optional chaining for `sourceMapCallback`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -251,8 +251,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 			if (result.map)
 			{
-				if (pluginOptions.sourceMapCallback)
-					pluginOptions.sourceMapCallback(id, result.map);
+				pluginOptions.sourceMapCallback?.(id, result.map);
 				transformResult.map = JSON.parse(result.map);
 			}
 


### PR DESCRIPTION
## Summary

Tiny one-liner change to use optional chaining
- following other optional chaining simplifications like #356, #335

## Misc

Is `sourceMapCallback` actually used by anyone? It's not listed in the docs so I didn't know it was a thing until I saw it in the code