### PR TITLE
fix(host): `getScriptSnapshot` must also call `fileNames.add`

### DIFF
--- a/src/host.ts
+++ b/src/host.ts
@@ -27,11 +27,11 @@ export class LanguageServiceHost implements tsTypes.LanguageServiceHost
 		this.service = service;
 	}
 
-	public setSnapshot(fileName: string, data: string): tsTypes.IScriptSnapshot
+	public setSnapshot(fileName: string, source: string): tsTypes.IScriptSnapshot
 	{
 		fileName = normalize(fileName);
 
-		const snapshot = tsModule.ScriptSnapshot.fromString(data);
+		const snapshot = tsModule.ScriptSnapshot.fromString(source);
 		this.snapshots[fileName] = snapshot;
 		this.versions[fileName] = (this.versions[fileName] || 0) + 1;
 		this.fileNames.add(fileName);
@@ -47,11 +47,7 @@ export class LanguageServiceHost implements tsTypes.LanguageServiceHost
 
 		const source = tsModule.sys.readFile(fileName);
 		if (source)
-		{
-			this.snapshots[fileName] = tsModule.ScriptSnapshot.fromString(source);
-			this.versions[fileName] = (this.versions[fileName] || 0) + 1;
-			return this.snapshots[fileName];
-		}
+			return this.setSnapshot(fileName, source);
 
 		return undefined;
 	}


### PR DESCRIPTION
## Summary

Make `getScriptSnapshot` match/call `setSnapshot`. Previously, a `this.fileNames.add` call was added to `setSnapshot` but not `getScriptSnapshot`, causing a `Could not find source file` error.
- Fixes #271

## Details

- the `fileNames` Set that was previously introduced in the fix for #95 ([this line in the commit](https://github.com/ezolenko/rollup-plugin-typescript2/commit/c86e07bc0f2f875e3953ee651871830351d38452?w=1#diff-49ecc36f34e1f45bd5ed5039646b8eaa1e919ecf4bcdfed5eae5c356bf11bff8R39)) caused a regression during watch mode
  - this is because `setSnapshot` was updated to call `this.fileNames.add`, but `getScriptSnapshot` was not
    - instead of updating both to be the same, we can just call `setSnapshot` from `getScriptSnapshot` as this code is supposed to be identical
      - also rename `data` -> `source` for consistency and clarity (`source` is a more specific name)
      
See https://github.com/ezolenko/rollup-plugin-typescript2/issues/271#issuecomment-1163625864 and my other comment above it for a root cause analysis.