### PR TITLE
feat: support `emitDeclarationOnly`

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The plugin inherits all compiler options and file lists from your `tsconfig.json
 
 #### @rollup/plugin-node-resolve
 
-Must be before rollup-plugin-typescript2 in the plugin list, especially when `browser: true` option is used, see [#66](https://github.com/ezolenko/rollup-plugin-typescript2/issues/66)
+Must be before `rollup-plugin-typescript2` in the plugin list, especially when `browser: true` option is used, see [#66](https://github.com/ezolenko/rollup-plugin-typescript2/issues/66).
 
 #### @rollup/plugin-commonjs
 
@@ -199,8 +199,16 @@ See [#108](https://github.com/ezolenko/rollup-plugin-typescript2/issues/108)
 
 ### Declarations
 
-This plugin respects `declaration: true` in your `tsconfig.json` file. When set, it will emit `*.d.ts` files for your bundle. The resulting file(s) can then be used with the `types` property in your `package.json` file as described [here](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).
+This plugin respects `declaration: true` in your `tsconfig.json` file. When set, it will emit `*.d.ts` files for your bundle.
+The resulting file(s) can then be used with the `types` property in your `package.json` file as described [here](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html).<br />
 By default, the declaration files will be located in the same directory as the generated Rollup bundle. If you want to override this behavior and instead use the declarationDir set `useTsconfigDeclarationDir` to `true` in the plugin options.
+
+The above also applies to `declarationMap: true` and `*.d.ts.map` files for your bundle.
+
+This plugin also respects `emitDeclarationOnly: true` and will only emit declarations (and declaration maps, if enabled) if set in your `tsconfig.json`.
+If you use `emitDeclarationOnly`, you will need another plugin to compile any TypeScript sources, such as `@rollup/plugin-babel`, `rollup-plugin-esbuild`, `rollup-plugin-swc`, etc.
+When composing Rollup plugins this way, `rollup-plugin-typescript2` will perform type-checking and declaration generation, while another plugin performs the TypeScript to JavaScript compilation.<br />
+Some scenarios where this can be particularly useful: you want to use Babel plugins on TypeScript source, or you want declarations and type-checking for your Vite builds (**NOTE**: this space has not been fully explored yet).
 
 ### Watch mode
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,6 +247,14 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 				context.debug(() => `${blue("generated declarations")} for '${key}'`);
 			}
 
+			// if a user sets this compilerOption, they probably want another plugin (e.g. Babel, ESBuild) to transform their TS instead, while rpt2 just type-checks and/or outputs declarations
+			// note that result.code is non-existent if emitDeclarationOnly per https://github.com/ezolenko/rollup-plugin-typescript2/issues/268
+			if (parsedConfig.options.emitDeclarationOnly)
+			{
+				context.debug(() => `${blue("emitDeclarationOnly")} enabled, not transforming TS'`);
+				return undefined;
+			}
+
 			const transformResult: TransformResult = { code: result.code, map: { mappings: "" } };
 
 			if (result.map)


### PR DESCRIPTION
## Summary

Support `emitDeclarationOnly` by, well, only emitting declarations and type-checking, and otherwise passing to the next plugin to transform TS
- Fixes #268

## Details

- when `emitDeclarationOnly` is set, only perform type-checking and emit declarations, don't transform TS
  - `result.code` actually doesn't exist when `emitDeclarationOnly` is set anyway
    - this caused a confusing situation for users who were trying to use Babel (with Babel plugins) on TS and only use rpt2 for declarations
      - instead of getting any JS code, they would just get empty chunks, bc `result.code` is `undefined`
        - that's kind of buggy, it should probably either be forced to `false` or do what we're doing now, which is likely more intuitive / intended
          - note that other Rollup TS plugins just force it to `false`, but I'm not sure that's the most optimal behavior
  - so now, instead of getting an empty chunk, rpt2 will just pass to the next plugin, allowing for other plugins on the chain to process TS
    - this opens up some new use cases, like using in tandem with Babel plugins (e.g. with [`babel-plugin-typescript-to-proptypes`](https://github.com/milesj/babel-plugin-typescript-to-proptypes)) or using for type-checking and declaration generation while using Vite / ESBuild for compilation

- add a new paragraph to "Declarations" docs about this new feature and what it does and some examples of how it could be used
  - note that these are unexplored / untested integrations, so point that out in the docs too
  - also modify a self-reference further up in the docs to use code backticks for `rollup-plugin-typescript2`
- while at it, also add a line about declaration maps
- and reformat the existing paragraph a bit to match the style and improve readability
  - one sentence per line, which is all on the same paragraph in Markdown anyway
  - add a `<br />` element to add a new-line _within_ the paragraph for better readability / spacing
    - Markdown supports this only with two trailing spaces, which is difficult to see and the trailing whitespace can be trimmed by editors, so prefer `<br />`
    
Can see my root cause analysis in https://github.com/ezolenko/rollup-plugin-typescript2/issues/268#issuecomment-1164003201