### PR TITLE
docs/clean: formally deprecate `rollupCommonJSResolveHack`

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,7 @@ See [#108](https://github.com/ezolenko/rollup-plugin-typescript2/issues/108)
 
 * `rollupCommonJSResolveHack`: false
 
-	On windows typescript resolver favors POSIX path, while commonjs plugin (and maybe others?) uses native path as module id. This can result in `namedExports` being ignored if rollup happened to use typescript's resolution. Set to true to pass resolved module path through `resolve()` to match up with `rollup-plugin-commonjs`.
-
-	`rollup-plugin-commonjs` fixed this in `10.1.0`, so projects using this option who update to new version will be broken again.
-
-	This also works around the similar bug affecting code splitting (see [rollup/rollup#3094](https://github.com/rollup/rollup/issues/3094)).
+	_Deprecated_. OS native paths are now _always_ used since [`0.30.0`](https://github.com/ezolenko/rollup-plugin-typescript2/releases/0.30.0) (see [#251](https://github.com/ezolenko/rollup-plugin-typescript2/pull/251)), so this no longer has any effect -- as if it is always `true`.
 
 * `objectHashIgnoreUnknownHack`: false
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@rollup/pluginutils": "^4.1.2",
         "find-cache-dir": "^3.3.2",
         "fs-extra": "^10.0.0",
-        "resolve": "^1.20.0",
         "tslib": "^2.4.0"
       },
       "devDependencies": {
@@ -2420,6 +2419,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/gensync": {
@@ -2504,6 +2504,7 @@
     },
     "node_modules/has": {
       "version": "1.0.3",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.1"
@@ -2585,6 +2586,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.2.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has": "^1.0.3"
@@ -4995,6 +4997,7 @@
     },
     "node_modules/path-parse": {
       "version": "1.0.7",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -5089,6 +5092,7 @@
     },
     "node_modules/resolve": {
       "version": "1.20.0",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "is-core-module": "^2.2.0",
@@ -7602,7 +7606,8 @@
       "optional": true
     },
     "function-bind": {
-      "version": "1.1.1"
+      "version": "1.1.1",
+      "dev": true
     },
     "gensync": {
       "version": "1.0.0-beta.2",
@@ -7660,6 +7665,7 @@
     },
     "has": {
       "version": "1.0.3",
+      "dev": true,
       "requires": {
         "function-bind": "^1.1.1"
       }
@@ -7716,6 +7722,7 @@
     },
     "is-core-module": {
       "version": "2.2.0",
+      "dev": true,
       "requires": {
         "has": "^1.0.3"
       }
@@ -9498,7 +9505,8 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.7"
+      "version": "1.0.7",
+      "dev": true
     },
     "picocolors": {
       "version": "1.0.0",
@@ -9566,6 +9574,7 @@
     },
     "resolve": {
       "version": "1.20.0",
+      "dev": true,
       "requires": {
         "is-core-module": "^2.2.0",
         "path-parse": "^1.0.6"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@rollup/pluginutils": "^4.1.2",
     "find-cache-dir": "^3.3.2",
     "fs-extra": "^10.0.0",
-    "resolve": "^1.20.0",
     "tslib": "^2.4.0"
   },
   "peerDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -164,7 +164,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 			// TODO: use module resolution cache
 			const result = tsModule.nodeModuleNameResolver(importee, importer, parsedConfig.options, tsModule.sys);
-			let resolved = result.resolvedModule?.resolvedFileName;
+			const resolved = result.resolvedModule?.resolvedFileName;
 
 			if (!resolved)
 				return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
-import { relative, dirname, normalize as pathNormalize, resolve as pathResolve } from "path";
+import { relative, dirname, normalize as pathNormalize, resolve } from "path";
 import * as tsTypes from "typescript";
 import { PluginImpl, PluginContext, InputOptions, OutputOptions, TransformResult, SourceMap, Plugin } from "rollup";
 import { normalizePath as normalize } from "@rollup/pluginutils";
 import * as _ from "lodash";
 import { blue, red, yellow, green } from "colors/safe";
-import * as resolve from "resolve";
 import findCacheDir from "find-cache-dir";
 
 import { RollupContext } from "./rollupcontext";
@@ -118,6 +117,9 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 				if (pluginOptions.objectHashIgnoreUnknownHack)
 					context.warn(() => `${yellow("You are using 'objectHashIgnoreUnknownHack' option")}. If you enabled it because of async functions, try disabling it now.`);
 
+				if (pluginOptions.rollupCommonJSResolveHack)
+					context.warn(() => `${yellow("You are using 'rollupCommonJSResolveHack' option")}. This is no longer needed, try disabling it now.`);
+
 				if (watchMode)
 					context.info(`running in watch mode`);
 			}
@@ -172,9 +174,6 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 			if (resolved.endsWith(".d.ts"))
 				return;
-
-			if (pluginOptions.rollupCommonJSResolveHack)
-				resolved = resolve.sync(resolved);
 
 			context.debug(() => `${blue("resolving")} '${importee}' imported by '${importer}'`);
 			context.debug(() => `    to '${resolved}'`);
@@ -337,7 +336,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 					// invert back to absolute, then make relative to declarationDir
 					parsedText.sources = parsedText.sources.map(source =>
 					{
-						const absolutePath = pathResolve(cachePlaceholder, source);
+						const absolutePath = resolve(cachePlaceholder, source);
 						return normalize(relative(declarationDir, absolutePath));
 					});
 					entryText = JSON.stringify(parsedText);


### PR DESCRIPTION
## Summary

Formally deprecate `rollupCommonJSResolveHack` as it's been obsolete since [0.30.0](https://github.com/ezolenko/rollup-plugin-typescript2/releases/0.30.0)

## Details

- this has had no effect since #251
  - that changed the code to always return OS native paths via the NodeJS Path API
    - so setting `rollupCommonJSResolveHack` would make no difference either `true` or `false`
      - effectively, it's as if it's always `true` now

- formally state now that this is deprecated in the docs
  - as well as when that occurred and what it means

- also add a warning in `options` similar to the existing one for `objectHashIgnoreUnknownHack` (from cd76b42f5509b8ab7b1564373ed2b2ce0d5c7bdd, which was added to my first major contribution back in #203 🙂 )

- remove the `resolve` dependency as well
  - it turns out something in the devDeps still uses it, so it didn't get fully removed in the `package-lock.json`
  - `resolve` was never needed anyway as we could've used NodeJS's native `path.resolve` or `require.resolve` instead (noted this at the bottom of https://github.com/ezolenko/rollup-plugin-typescript2/issues/234#issuecomment-1139202740)
    - `resolve` was created for `browserify` after all, where one can't use NodeJS APIs
      - but we run on NodeJS and can and already do use NodeJS APIs, including both `path.resolve` _and_ `require.resolve`
  - I actually started this PR just to remove the dep, then realized the entire code path is obsolete 😅  😅 

## References

- Per above, this was made obsolete in #251
  - Which turns out is a fix for #169 
  - And a workaround for https://github.com/rollup/rollup/issues/3094
- Original issue in `rollup-plugin-commonjs`: https://github.com/rollup/rollup-plugin-commonjs/issues/177
  - Which was fixed by https://github.com/rollup/rollup-plugin-commonjs/pull/406
    - Related: I actually don't think your [old comment](https://github.com/rollup/rollup-plugin-commonjs/pull/406#issuecomment-525035273) there is correct; so long as `commonjs` is _internally_ consistent, it shouldn't matter what kind of paths are passed to it, as it is normalized to the same string either way
  - and released in [`10.1.0`](https://github.com/rollup/rollup-plugin-commonjs/blob/master/CHANGELOG.md#1010), which seems to have been the last version before the move to `@rollup/plugin-commonjs`
