### PR TITLE
clean(cache): remove unused `checkNewCache` parameter

### DIFF
--- a/__tests__/rollingcache.spec.ts
+++ b/__tests__/rollingcache.spec.ts
@@ -27,7 +27,7 @@ afterAll(() => remove(testDir));
 
 
 test("RollingCache", async () => {
-	const cache = new RollingCache(testDir, true);
+	const cache = new RollingCache(testDir);
 
 	expect(cache.exists(nonExistentFile)).toBeFalsy();
 	expect(cache.exists(testFile)).toBeTruthy();
@@ -50,7 +50,7 @@ test("RollingCache", async () => {
 });
 
 test("RollingCache, rolled", async () => {
-	const cache = new RollingCache(testDir, true);
+	const cache = new RollingCache(testDir);
 	// roll the cache
 	cache.roll();
 	// rolling again hits coverage for this.rolled being true already
@@ -65,8 +65,8 @@ test("RollingCache, rolled", async () => {
 	expect(await pathExists(`${oldCacheDir}/touched.json`)).toBeFalsy();
 });
 
-test("RollingCache, test checkNewCache", async () => {
-	const cache = new RollingCache(testDir, true);
+test("RollingCache, test newCache", async () => {
+	const cache = new RollingCache(testDir);
 
 	const preExistingFile = `${newCacheDir}/pre-existing.json`;
 	await writeFile(preExistingFile, JSON.stringify({}));
@@ -74,7 +74,7 @@ test("RollingCache, test checkNewCache", async () => {
 });
 
 test("RollingCache, test match when oldCacheDir is empty", () => {
-	const cache = new RollingCache(emptyCacheRoot, true);
+	const cache = new RollingCache(emptyCacheRoot);
 
 	expect(cache.match([])).toBeTruthy();
 	expect(cache.match([testFile])).toBeFalsy();

--- a/src/rollingcache.ts
+++ b/src/rollingcache.ts
@@ -14,26 +14,21 @@ export class RollingCache<DataType> implements ICache<DataType>
 	private newCacheRoot: string;
 	private rolled: boolean = false;
 
-	/**
-	 * @param cacheRoot: root folder for the cache
-	 * @param checkNewCache: whether to also look in new cache when reading from cache
-	 */
-	constructor(private cacheRoot: string, private checkNewCache: boolean)
+	/** @param cacheRoot: root folder for the cache */
+	constructor(private cacheRoot: string)
 	{
 		this.oldCacheRoot = `${this.cacheRoot}/cache`;
 		this.newCacheRoot = `${this.cacheRoot}/cache_`;
 		emptyDirSync(this.newCacheRoot);
 	}
 
-	/**
-	 * @returns true if name exist in old cache (or either old of new cache if checkNewCache is true)
-	 */
+	/** @returns true if name exists in either old cache or new cache */
 	public exists(name: string): boolean
 	{
 		if (this.rolled)
 			return false;
 
-		if (this.checkNewCache && existsSync(`${this.newCacheRoot}/${name}`))
+		if (existsSync(`${this.newCacheRoot}/${name}`))
 			return true;
 
 		return existsSync(`${this.oldCacheRoot}/${name}`);
@@ -44,9 +39,7 @@ export class RollingCache<DataType> implements ICache<DataType>
 		return `${this.oldCacheRoot}/${name}`;
 	}
 
-	/**
-	 * @returns true if old cache contains all names and nothing more
-	 */
+	/** @returns true if old cache contains all names and nothing more */
 	public match(names: string[]): boolean
 	{
 		if (this.rolled)
@@ -58,12 +51,10 @@ export class RollingCache<DataType> implements ICache<DataType>
 		return _.isEqual(readdirSync(this.oldCacheRoot).sort(), names.sort());
 	}
 
-	/**
-	 * @returns data for name, must exist in old cache (or either old of new cache if checkNewCache is true)
-	 */
+	/** @returns data for name, must exist in either old cache or new cache */
 	public read(name: string): DataType | null | undefined
 	{
-		if (this.checkNewCache && existsSync(`${this.newCacheRoot}/${name}`))
+		if (existsSync(`${this.newCacheRoot}/${name}`))
 			return readJsonSync(`${this.newCacheRoot}/${name}`, { encoding: "utf8", throws: false });
 
 		return readJsonSync(`${this.oldCacheRoot}/${name}`, { encoding: "utf8", throws: false });
@@ -84,12 +75,11 @@ export class RollingCache<DataType> implements ICache<DataType>
 	{
 		if (this.rolled)
 			return;
+
 		ensureFileSync(`${this.newCacheRoot}/${name}`);
 	}
 
-	/**
-	 * clears old cache and moves new in its place
-	 */
+	/** clears old cache and moves new in its place */
 	public roll()
 	{
 		if (this.rolled)

--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -281,10 +281,10 @@ export class TsCache
 
 	private init()
 	{
-		this.codeCache = new RollingCache<ICode>(`${this.cacheDir}/code`, true);
-		this.typesCache = new RollingCache<string>(`${this.cacheDir}/types`, true);
-		this.syntacticDiagnosticsCache = new RollingCache<IDiagnostics[]>(`${this.cacheDir}/syntacticDiagnostics`, true);
-		this.semanticDiagnosticsCache = new RollingCache<IDiagnostics[]>(`${this.cacheDir}/semanticDiagnostics`, true);
+		this.codeCache = new RollingCache<ICode>(`${this.cacheDir}/code`);
+		this.typesCache = new RollingCache<string>(`${this.cacheDir}/types`);
+		this.syntacticDiagnosticsCache = new RollingCache<IDiagnostics[]>(`${this.cacheDir}/syntacticDiagnostics`);
+		this.semanticDiagnosticsCache = new RollingCache<IDiagnostics[]>(`${this.cacheDir}/semanticDiagnostics`);
 	}
 
 	private markAsDirty(id: string): void


### PR DESCRIPTION
## Summary

The `checkNewCache` parameter in `RollingCache` is always set to `true`, so remove it to simplify the code

## Details

- it is set to `true` in every usage, so just always check the new cache and remove the parameter entirely
  - rewrite the comments to reflect this change
    - and condense them a bit
  - modify tests a bit to reflect this change as well