### PR TITLE
fix(cache): invalidate `codeCache` in most cases when imports change

### DIFF
--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -213,8 +213,8 @@ export class TsCache
 	public getCompiled(id: string, snapshot: tsTypes.IScriptSnapshot, transform: () => ICode | undefined): ICode | undefined
 	{
 		this.context.info(`${blue("transpiling")} '${id}'`);
-		// the compiled JS code will not change if imports do, but the declarations can change based on imports' types changing, so only check imports when declarations are needed
-		return this.getCached(this.codeCache, id, snapshot, Boolean(this.options.declaration), transform);
+		// if !isolatedModules, compiled JS code can change if its imports do (e.g. enums). also, declarations can change based on imports as well
+		return this.getCached(this.codeCache, id, snapshot, Boolean(!this.options.isolatedModules || this.options.declaration), transform);
 	}
 
 	public getSyntacticDiagnostics(id: string, snapshot: tsTypes.IScriptSnapshot, check: () => tsTypes.Diagnostic[]): IDiagnostics[]

--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -213,7 +213,8 @@ export class TsCache
 	public getCompiled(id: string, snapshot: tsTypes.IScriptSnapshot, transform: () => ICode | undefined): ICode | undefined
 	{
 		this.context.info(`${blue("transpiling")} '${id}'`);
-		return this.getCached(this.codeCache, id, snapshot, false, transform);
+		// the compiled JS code will not change if imports do, but the declarations can change based on imports' types changing, so only check imports when declarations are needed
+		return this.getCached(this.codeCache, id, snapshot, Boolean(this.options.declaration), transform);
 	}
 
 	public getSyntacticDiagnostics(id: string, snapshot: tsTypes.IScriptSnapshot, check: () => tsTypes.Diagnostic[]): IDiagnostics[]


### PR DESCRIPTION
## Summary

The `codeCache` should be invalidated when imports change if declarations are needed, because imports' types can change the resulting declaration. 
- Fixes #292

**EDIT**: also added `!isolatedModules` to the check, see below comments regarding, e.g. enums, that could cause compiled JS code to change as well when imports change

## Details

- previously, the `checkImports` flag was set to `true` for type-checking, but `false` for compilation
  - I _believe_ it is `false` because the compiled JS shouldn't change if an import changes
    - though I'm not sure if that was the original intent behind the code
  - problematically though, compilation results can include declarations, and those _can_ change if imports change
    - for instance, the types of an import can change the declaration that is output
  - so now, only set it to `false` for compilation if declarations are _not_ needed

See my root cause analysis in https://github.com/ezolenko/rollup-plugin-typescript2/issues/292#issuecomment-1152951087