### PR TITLE
fix(diagnostics): `pretty` defaults to `true` in TS 2.9+

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 	const typecheckFile = (id: string, snapshot: tsTypes.IScriptSnapshot, tcContext: IContext) =>
 	{
 			const diagnostics = getDiagnostics(id, snapshot);
-			printDiagnostics(tcContext, diagnostics, parsedConfig.options.pretty === true);
+			printDiagnostics(tcContext, diagnostics, parsedConfig.options.pretty !== false);
 
 			if (diagnostics.length > 0)
 				noErrors = false;
@@ -131,7 +131,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			// printing compiler option errors
 			if (pluginOptions.check) {
 				const diagnostics = convertDiagnostic("options", service.getCompilerOptionsDiagnostics());
-				printDiagnostics(context, diagnostics, parsedConfig.options.pretty === true);
+				printDiagnostics(context, diagnostics, parsedConfig.options.pretty !== false);
 				if (diagnostics.length > 0)
 					noErrors = false;
 			}

--- a/src/parse-tsconfig.ts
+++ b/src/parse-tsconfig.ts
@@ -20,7 +20,7 @@ export function parseTsConfig(context: IContext, pluginOptions: IOptions)
 	let loadedConfig: any = {};
 	let baseDir = pluginOptions.cwd;
 	let configFileName;
-	let pretty = false;
+	let pretty = true;
 	if (fileName)
 	{
 		const text = tsModule.sys.readFile(fileName);

--- a/src/print-diagnostics.ts
+++ b/src/print-diagnostics.ts
@@ -4,7 +4,7 @@ import { tsModule } from "./tsproxy";
 import { IContext } from "./context";
 import { IDiagnostics } from "./tscache";
 
-export function printDiagnostics(context: IContext, diagnostics: IDiagnostics[], pretty: boolean): void
+export function printDiagnostics(context: IContext, diagnostics: IDiagnostics[], pretty = true): void
 {
 	diagnostics.forEach((diagnostic) =>
 	{


### PR DESCRIPTION
## Summary

Changes the default configuration of `pretty`, so now pretty-printing is the default, as it is for `tsc` and in the TSConfig Reference.

## Details

- per https://www.typescriptlang.org/tsconfig#pretty
  - TS 2.9 [changed the default](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-9.html#--pretty-output-by-default) to `true`
     - so this is a legacy remnant of older versions of TS
- this is why `tsc` by default pretty prints, even when `pretty` is unset
  - only if it is _explicitly_ set to `false` does it not do that

- so change rpt2's diagnostic printing to be `pretty` by default as well
  - I think this is a pretty _big_ DX improvement, to be honest
  - I always thought something was up with the error reporting, but saw that there was code for `pretty`, so didn't quite connect the dots until now
    - that while there was code for it, the default was wrong, and so unless I set `pretty: true`, I wasn't getting easier to read printing
      - and given that `pretty: true` is the default, that's a redundant / unnecessary option to set in `tsconfig` that I normally wouldn't ever re-set

## Review Notes

Only thing I'm not sure of is non-tty environments, that I didn't even think of until I read the TS 2.9 release notes (as linked above). Not exactly sure if TS will handle those automatically, or if we need to add a check for that as well... 🤔 

It's also a bit hard to check as well... though first priority should be local dev in either case.

## References

- Support for pretty-printing diagnostics was originally added in #47 , which I believe pre-dates TS 2.9