### PR TITLE
fix(diagnostics): workaround Rollup duplicating error messages

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -261,7 +261,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			// workaround: err.stack contains err.message and Rollup prints both, causing duplication, so split out the stack itself if it exists (c.f. https://github.com/ezolenko/rollup-plugin-typescript2/issues/103#issuecomment-1172820658)
 			const stackOnly = err.stack?.split(err.message)[1];
 			if (stackOnly)
-				this.error({ message: err.message, stack: stackOnly });
+				this.error({ ...err, message: err.message, stack: stackOnly });
 			else
 				this.error(err);
 		},

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,6 +253,19 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			return transformResult;
 		},
 
+		buildEnd(err)
+		{
+			if (!err)
+				return
+
+			// workaround: err.stack contains err.message and Rollup prints both, causing duplication, so split out the stack itself if it exists (c.f. https://github.com/ezolenko/rollup-plugin-typescript2/issues/103#issuecomment-1172820658)
+			const stackOnly = err.stack?.split(err.message)[1];
+			if (stackOnly)
+				this.error({ message: err.message, stack: stackOnly });
+			else
+				this.error(err);
+		},
+
 		generateBundle(bundleOptions)
 		{
 			self._ongenerate();


### PR DESCRIPTION
## Summary

Adds a workaround for a Rollup bug that causes duplicate error messages
- Fixes #103
- Goes along with #372, which makes this bug much more noticeable

## Details

- per https://github.com/ezolenko/rollup-plugin-typescript2/issues/103#issuecomment-1172820658 and my investigation in #372, it seems like Rollup has a bug where it duplicates some error message
  - this occurs when the error has a stack (or frame) which contains the error message itself
    - Rollup prints _both_ the error message _and_ the stack in that case, causing duplication

- this fix adds a workaround for this upstream Rollup bug
  - it detects if there is a stack and if the message is duplicated in the stack
    - if so, it removes the duplication in the stack
  - this workaround should be forward-compatible if this behavior is fixed upstream
    - this code should just end up re-throwing in that case (effectively a no-op)

## Review Notes

This is gonna merge conflict pretty hard with #345 's current code (as these both add the `buildEnd` hook), but I made them both compatible with each other. Will just have to update one or the other when one is merged

## Future Work

I'll make a PR to Rollup proper and link it here as well