### PR TITLE
clean: remove backward-compat checks for old Rollup versions

### DIFF
--- a/__tests__/rollupcontext.spec.ts
+++ b/__tests__/rollupcontext.spec.ts
@@ -12,9 +12,7 @@ import { RollupContext } from "../src/rollupcontext";
 test("RollupContext", () => {
 	const data = {};
 	const stubbedContext = makeStubbedContext(data);
-
 	const context = new RollupContext(5, false, stubbedContext);
-	expect(Object.keys(context)).toEqual(["verbosity", "bail", "context", "prefix", "hasContext"]);
 
 	context.warn("test");
 	expect((data as any).warn).toEqual("test");
@@ -27,23 +25,6 @@ test("RollupContext", () => {
 
 	context.error(() => "test2!");
 	expect((data as any).warn).toEqual("test2!");
-});
-
-test("RollupContext with no logger", () => {
-	const data = {};
-	const stubbedContext = makeStubbedContext(data);
-	delete (stubbedContext as any).warn;
-	delete (stubbedContext as any).error;
-	delete (stubbedContext as any).info;
-	delete (stubbedContext as any).debug;
-
-	const context = new RollupContext(5, false, stubbedContext);
-
-	context.warn("test");
-	expect(console.log).toHaveBeenLastCalledWith("test");
-
-	context.error("test2");
-	expect(console.log).toHaveBeenLastCalledWith("test2");
 
 	context.info("test3");
 	expect(console.log).toHaveBeenLastCalledWith("test3");

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import { relative, dirname, normalize as pathNormalize, resolve } from "path";
 import * as tsTypes from "typescript";
 import { PluginImpl, PluginContext, InputOptions, OutputOptions, TransformResult, SourceMap, Plugin } from "rollup";
 import { normalizePath as normalize } from "@rollup/pluginutils";
-import * as _ from "lodash";
 import { blue, red, yellow, green } from "colors/safe";
 import findCacheDir from "find-cache-dir";
 
@@ -103,8 +102,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			{
 				context.info(`typescript version: ${tsModule.version}`);
 				context.info(`tslib version: ${tslibVersion}`);
-				if (this.meta)
-					context.info(`rollup version: ${this.meta.rollupVersion}`);
+				context.info(`rollup version: ${this.meta.rollupVersion}`);
 
 				context.info(`rollup-plugin-typescript2 version: $RPT2_VERSION`);
 				context.debug(() => `plugin options:\n${JSON.stringify(pluginOptions, (key, value) => key === "typescript" ? `version ${(value as typeof tsModule).version}` : value, 4)}`);
@@ -205,8 +203,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 					// since no output was generated, aborting compilation
 					cache().done();
-					if (_.isFunction(this.error))
-						this.error(red(`failed to transpile '${id}'`));
+					this.error(red(`failed to transpile '${id}'`));
 				}
 
 				const references = getAllReferences(id, snapshot, parsedConfig.options);
@@ -219,10 +216,11 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			if (!result)
 				return undefined;
 
-			if (watchMode && this.addWatchFile && result.references)
+			if (watchMode && result.references)
 			{
 				if (tsConfigPath)
 					this.addWatchFile(tsConfigPath);
+
 				result.references.map(this.addWatchFile, this);
 				context.debug(() => `${green("    watching")}: ${result.references!.join("\nrpt2:               ")}`);
 			}

--- a/src/rollupcontext.ts
+++ b/src/rollupcontext.ts
@@ -5,11 +5,8 @@ import { IContext, VerbosityLevel } from "./context";
 
 export class RollupContext implements IContext
 {
-	private hasContext: boolean = true;
-
 	constructor(private verbosity: VerbosityLevel, private bail: boolean, private context: PluginContext, private prefix: string = "")
 	{
-		this.hasContext = _.isFunction(this.context.warn) && _.isFunction(this.context.error);
 	}
 
 	public warn(message: string | (() => string)): void
@@ -18,11 +15,7 @@ export class RollupContext implements IContext
 			return;
 
 		const text = _.isFunction(message) ? message() : message;
-
-		if (this.hasContext)
-			this.context.warn(`${text}`);
-		else
-			console.log(`${this.prefix}${text}`);
+		this.context.warn(`${text}`);
 	}
 
 	public error(message: string | (() => string)): void
@@ -32,15 +25,10 @@ export class RollupContext implements IContext
 
 		const text = _.isFunction(message) ? message() : message;
 
-		if (this.hasContext)
-		{
-			if (this.bail)
-				this.context.error(`${text}`);
-			else
-				this.context.warn(`${text}`);
-		}
+		if (this.bail)
+			this.context.error(`${text}`);
 		else
-			console.log(`${this.prefix}${text}`);
+			this.context.warn(`${text}`);
 	}
 
 	public info(message: string | (() => string)): void
@@ -49,7 +37,6 @@ export class RollupContext implements IContext
 			return;
 
 		const text = _.isFunction(message) ? message() : message;
-
 		console.log(`${this.prefix}${text}`);
 	}
 
@@ -59,7 +46,6 @@ export class RollupContext implements IContext
 			return;
 
 		const text = _.isFunction(message) ? message() : message;
-
 		console.log(`${this.prefix}${text}`);
 	}
 }


### PR DESCRIPTION
## Summary

Clean up some old backward-compat checks that are no longer necessary for the minimum version of Rollup that rpt2 requires
- Follow-up to https://github.com/ezolenko/rollup-plugin-typescript2/pull/345#issuecomment-1170542354, where I realized several of these checks were legacy and no longer needed

## Details
- we require Rollup `>=1.26.3` in the peerDeps and the README and have for years now
  - (and Rollup is currently at `2.75.7`, so this is a pretty low target)
  - as such, we can remove various checks that are legacy backward-compat remnants for old Rollup versions:
    - `this.meta` was added to `options` in `1.1.0`: https://github.com/rollup/rollup/blob/master/CHANGELOG.md#110
    - `this.addWatchFile` was added at least in `1.0.0`: https://github.com/rollup/rollup/blob/master/CHANGELOG.md#100
    - `this.error` and `this.warn` were added to `transform` in `0.41.0`: https://github.com/rollup/rollup/blob/master/CHANGELOG.md#0410

- this simplifies some of the code a decent bit, `RollupContext` in particular
  - see also the usage of `buildEnd` in #345

- modify tests to account for these changes; basically just simplify them
  - and remove the check against private internals of the class, as they're private
    - guess I forgot to remove this when I was refactoring the test code in #321?

## Future Work

- More follow-ups to #328 to remove more `lodash` usage
  - The rest of the `_.isFunction` usage can be replaced with a check for the opposite condition, i.e. `typeof message === "string" ? message : message()`
  - `_.merge`, `_.isEqual`, and `_.compact` would be the only ones leftover after