### PR TITLE
docs: mention `module: "ES2020"` compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The plugin inherits all compiler options and file lists from your `tsconfig.json
 
 #### Some compiler options have more than one compatible value.
 
-* `module`: defaults to `ES2015`, other valid value is `ESNext` (required for dynamic imports, see [#54](https://github.com/ezolenko/rollup-plugin-typescript2/issues/54)).
+* `module`: defaults to `ES2015`. Other valid values are `ES2020` and `ESNext` (required for dynamic imports, see [#54](https://github.com/ezolenko/rollup-plugin-typescript2/issues/54)).
 
 #### Some options need additional configuration on plugin side
 

--- a/__tests__/check-tsconfig.spec.ts
+++ b/__tests__/check-tsconfig.spec.ts
@@ -13,7 +13,7 @@ test("checkTsConfig", () => {
 		...defaultConfig,
 		options: { module: ts.ModuleKind.None },
 	})).toThrow(
-		`Incompatible tsconfig option. Module resolves to 'None'. This is incompatible with rollup, please use 'module: "ES2015"' or 'module: "ESNext"'.`,
+		"Incompatible tsconfig option. Module resolves to 'None'. This is incompatible with Rollup, please use",
 	);
 
 	expect(checkTsConfig({

--- a/src/check-tsconfig.ts
+++ b/src/check-tsconfig.ts
@@ -6,6 +6,6 @@ export function checkTsConfig(parsedConfig: tsTypes.ParsedCommandLine): void
 {
 	const module = parsedConfig.options.module!;
 
-	if (module !== tsModule.ModuleKind.ES2015 && module !== tsModule.ModuleKind.ESNext && module !== tsModule.ModuleKind.ES2020)
-		throw new Error(`Incompatible tsconfig option. Module resolves to '${tsModule.ModuleKind[module]}'. This is incompatible with rollup, please use 'module: "ES2015"' or 'module: "ESNext"'.`);
+	if (module !== tsModule.ModuleKind.ES2015 && module !== tsModule.ModuleKind.ES2020 && module !== tsModule.ModuleKind.ESNext)
+		throw new Error(`Incompatible tsconfig option. Module resolves to '${tsModule.ModuleKind[module]}'. This is incompatible with Rollup, please use 'module: "ES2015"', 'module: "ES2020"', or 'module: "ESNext"'.`);
 }


### PR DESCRIPTION
## Summary

Update docs and `check-tsconfig` error message to mention `module: "ES2020"` compatibility

## Details

- it's already been supported since eb1dd17babde0b22e9540b12e671eb56d9d6bce0, but the docs and error message were not updated to mention it
  - so add both to make sure users aren't confused
  - also re-order it to be ES2015, ES2020, then ESNext consistently, which is their module order (c.f. https://github.com/microsoft/TypeScript/issues/24082)

- modify test to account for the new error message
  - make it a bit more resilient to change by only testing a substring as well (c.f. https://jestjs.io/docs/expect#tothrowerror)