### PR TITLE
fix(test): handle `pretty` formatting

### DIFF
--- a/__tests__/integration/errors.spec.ts
+++ b/__tests__/integration/errors.spec.ts
@@ -2,7 +2,6 @@ import { jest, afterAll, test, expect } from "@jest/globals";
 import * as path from "path";
 import { normalizePath as normalize } from "@rollup/pluginutils";
 import * as fs from "fs-extra";
-import { red } from "colors/safe";
 
 import { RPT2Options } from "../../src/index";
 import * as helpers from "./helpers";
@@ -39,7 +38,7 @@ test("integration - tsconfig errors", async () => {
 });
 
 test("integration - semantic error", async () => {
-  expect(genBundle("semantic.ts")).rejects.toThrow(`semantic error TS2322: ${red("Type 'string' is not assignable to type 'number'.")}`);
+  expect(genBundle("semantic.ts")).rejects.toThrow("Type 'string' is not assignable to type 'number'.");
 });
 
 test("integration - semantic error - abortOnError: false / check: false", async () => {
@@ -56,7 +55,7 @@ test("integration - semantic error - abortOnError: false / check: false", async 
 });
 
 test("integration - syntax error", () => {
-  expect(genBundle("syntax.ts")).rejects.toThrow(`syntax error TS1005: ${red("';' expected.")}`);
+  expect(genBundle("syntax.ts")).rejects.toThrow("';' expected.");
 });
 
 test("integration - syntax error - abortOnError: false / check: false", () => {


### PR DESCRIPTION
## Summary

The integration tests (#371) and `pretty` default change (#372) got merged simultaneously, so the tests need to be updated to handle the new `pretty` default
- `master` is currently [failing CI](https://github.com/ezolenko/rollup-plugin-typescript2/runs/7208202793?check_suite_focus=true) due to this

## Details

<!--
  A **detailed** description of what this PR changes and _why_ it changes that.
-->

- the coloration of the errors is quite different when using `pretty`
  - so instead of re-implementing TS's colors in the tests, just test a portion that is the same color: the error text
- also TS doesn't specify semantic vs. syntax, that's something `print-diagnostics` does

- this test is more resilient to change as well I suppose since no error codes or colors

## Future Work

Add unit tests for both `pretty` and non-`pretty` versions of errors; currently `print-diagnostics` is one of the few files without unit test coverage