### PR TITLE
docs: mention `transpileOnly` in `check: false`

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ See [#108](https://github.com/ezolenko/rollup-plugin-typescript2/issues/108)
 * `check`: true
 
 	Set to false to avoid doing any diagnostic checks on the code.
+	Setting to false is sometimes referred to as `transpileOnly` by other TypeScript integrations.
 
 * `verbosity`: 1
 


### PR DESCRIPTION
## Summary

`check: false` is sometimes known as `transpileOnly` in other TS integrations
- Fixes #302 

## Details

- this is a common name in other TS integrations and has been mentioned in the issues before
  - so add it in the docs for searchability
