### PR TITLE
docs: add a permalink to the og rpt

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 Rollup plugin for typescript with compiler errors.
 
-This is a rewrite of the original `rollup-plugin-typescript`, starting and borrowing from [this fork](https://github.com/alexlur/rollup-plugin-typescript).
+This is a rewrite of the [original](https://github.com/rollup/rollup-plugin-typescript/tree/v0.8.1) `rollup-plugin-typescript`, starting and borrowing from [this fork](https://github.com/alexlur/rollup-plugin-typescript).
 
 This version is somewhat slower than the original, but it will print out TypeScript syntactic and semantic diagnostic messages (the main reason for using TypeScript after all).
 


### PR DESCRIPTION
## Summary

Add a permalink back to the specific previous version of `rollup-plugin-typescript` that `alexlur`'s fork likely started from
- Closes #307 by incorporating https://github.com/ezolenko/rollup-plugin-typescript2/pull/307#discussion_r895089906

## Details

- as the `alexlur` fork no longer exists / 404s, permalink back to og rpt (rpt1)
  - which is archived and still exists under the `rollup` org
  - as requested in issues