### PR TITLE
fix: add back `noErrors = false` to `emitSkipped`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -198,6 +198,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 				if (output.emitSkipped)
 				{
+					noErrors = false;
 					// always checking on fatal errors, even if options.check is set to false
 					typecheckFile(id, snapshot, contextWrapper);
 


### PR DESCRIPTION
## Summary

Make `noErrors = false` unconditional again in `emitSkipped`
- Follow-up to https://github.com/ezolenko/rollup-plugin-typescript2/pull/344#discussion_r914336553

## Details

- apparently `emitSkipped` can indeed happen without there being a semantic or syntactic error
  - so add back the previous unconditional behavior of `noErrors`

- still not clear what exactly triggers `emitSkipped` though, see my TS issue https://github.com/microsoft/TypeScript/issues/49790