### PR TITLE
feat: add rpt2 prefix to remaining errors

### DIFF
--- a/src/check-tsconfig.ts
+++ b/src/check-tsconfig.ts
@@ -7,5 +7,5 @@ export function checkTsConfig(parsedConfig: tsTypes.ParsedCommandLine): void
 	const module = parsedConfig.options.module!;
 
 	if (module !== tsModule.ModuleKind.ES2015 && module !== tsModule.ModuleKind.ES2020 && module !== tsModule.ModuleKind.ESNext)
-		throw new Error(`Incompatible tsconfig option. Module resolves to '${tsModule.ModuleKind[module]}'. This is incompatible with Rollup, please use 'module: "ES2015"', 'module: "ES2020"', or 'module: "ESNext"'.`);
+		throw new Error(`rpt2: Incompatible tsconfig option. Module resolves to '${tsModule.ModuleKind[module]}'. This is incompatible with Rollup, please use 'module: "ES2015"', 'module: "ES2020"', or 'module: "ESNext"'.`);
 }

--- a/src/tslib.ts
+++ b/src/tslib.ts
@@ -15,6 +15,6 @@ try
 	tslibVersion = tslibPackage.version;
 } catch (e)
 {
-	console.warn("Error loading `tslib` helper library.");
+	console.warn("rpt2: Error loading `tslib` helper library.");
 	throw e;
 }


### PR DESCRIPTION
## Summary

Add `rpt2: ` prefix to remaining, unprefixed error messages
- Fixes #300

## Details

- most were added in ff8895103c8466694e7d8eeb734f51d2850670d8, but these two were missed

- this should now cover all **thrown** errors
  - they only get thrown in the [`options`](https://rollupjs.org/guide/en/#options) hook, which does not implement Rollup's `this.error`
  - all other errors are already auto-prefixed by RollupContext etc
