### PR TITLE
fix: missing `tsconfig` error shouldn't say `undefined`

### DIFF
--- a/__tests__/integration/errors.spec.ts
+++ b/__tests__/integration/errors.spec.ts
@@ -35,7 +35,7 @@ test("integration - tsconfig errors", async () => {
   // TODO: move to parse-tsconfig unit tests?
   expect(genBundle("semantic.ts", {
     tsconfig: "non-existent-tsconfig",
-  })).rejects.toThrow("rpt2: failed to open 'undefined'"); // FIXME: bug: this should be "non-existent-tsconfig", not "undefined"
+  })).rejects.toThrow("rpt2: failed to open 'non-existent-tsconfig'");
 });
 
 test("integration - semantic error", async () => {

--- a/src/parse-tsconfig.ts
+++ b/src/parse-tsconfig.ts
@@ -15,7 +15,7 @@ export function parseTsConfig(context: IContext, pluginOptions: IOptions)
 
 	// if the value was provided, but no file, fail hard
 	if (pluginOptions.tsconfig !== undefined && !fileName)
-		throw new Error(`rpt2: failed to open '${fileName}'`);
+		throw new Error(`rpt2: failed to open '${pluginOptions.tsconfig}'`);
 
 	let loadedConfig: any = {};
 	let baseDir = pluginOptions.cwd;


### PR DESCRIPTION
## Summary

Improve the error message when a `tsconfig` path doesn't have a file. The error message should say the path passed in, not `'undefined'`
- Fixes a bug I found while writing integration tests in #371 

## Details

- per the conditional above this line, `file` is falsey, so printing it doesn't make sense
  - per same conditional though, `pluginOptions.tsconfig` exists, so we can print that

- fixes a test `TODO`/`FIXME` that had to workaround this bug as well
