### PR TITLE
feat: capture watch mode when called via the Rollup API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			rollupOptions = {... config};
 			context = new ConsoleContext(pluginOptions.verbosity, "rpt2: ");
 
-			watchMode = process.env.ROLLUP_WATCH === "true";
+			watchMode = process.env.ROLLUP_WATCH === "true" || !!this.meta.watchMode; // meta.watchMode was added in 2.14.0 to capture watch via Rollup API (i.e. no env var) (c.f. https://github.com/rollup/rollup/blob/master/CHANGELOG.md#2140)
 			({ parsedTsConfig: parsedConfig, fileName: tsConfigPath } = parseTsConfig(context, pluginOptions));
 
 			if (generateRound === 0)


### PR DESCRIPTION
## Summary

Capture `this.meta.watchMode` when it is available

## Details

- `process.env.ROLLUP_WATCH` is only set when using the CLI
  - when using watch mode through [the Rollup API](https://rollupjs.org/guide/en/#rollupwatch), this is not set
  - but since Rollup [2.14.0](https://github.com/rollup/rollup/blob/master/CHANGELOG.md#2140), `this.meta.watchMode` is available
    - still check the env variable for backward-compat on older Rollup versions

- notably, this is needed to test watch mode, since the tests are done via the Rollup API