### PR TITLE
fix: don't duplicate type-only check on Windows

### DIFF
--- a/__tests__/integration/errors.spec.ts
+++ b/__tests__/integration/errors.spec.ts
@@ -10,7 +10,7 @@ import * as helpers from "./helpers";
 // increase timeout to 15s for whole file since CI occassionally timed out -- these are integration and cache tests, so longer timeout is warranted
 jest.setTimeout(15000);
 
-const local = (x: string) => path.resolve(__dirname, x);
+const local = (x: string) => normalize(path.resolve(__dirname, x));
 const cacheRoot = local("__temp/errors/rpt2-cache"); // don't use the one in node_modules
 
 afterAll(async () => {
@@ -20,7 +20,7 @@ afterAll(async () => {
 });
 
 async function genBundle(relInput: string, extraOpts?: RPT2Options, onwarn?: Mock) {
-  const input = normalize(local(`fixtures/errors/${relInput}`));
+  const input = local(`fixtures/errors/${relInput}`);
   return helpers.genBundle({
     input,
     tsconfig: local("fixtures/errors/tsconfig.json"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,6 +56,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 	const typecheckFile = (id: string, snapshot: tsTypes.IScriptSnapshot, tcContext: IContext) =>
 	{
+			id = normalize(id);
 			checkedFiles.add(id); // must come before print, as that could bail
 
 			const diagnostics = getDiagnostics(id, snapshot);


### PR DESCRIPTION
## Summary

Ensure that the type-only / "missed" type-check doesn't duplicate on Windows
- Fixes https://github.com/ezolenko/rollup-plugin-typescript2/pull/345#issuecomment-1182156954 and the currently [failing CI on `master`](https://github.com/ezolenko/rollup-plugin-typescript2/runs/7305629642?check_suite_focus=true)

## Details

- gotta remember to normalize file names 🙃
  - this fixes a failing test on Windows by fixing the underlying bug

- refactor: improve normalization in `errors.spec`
  - normalize _all_ calls to `local`, instead of just one
  - this doesn't affect the tests, only the source code change does, but I added this first and it's better practice / test future-proofing
  
## Review Notes

I confirmed [on CI on my fork](https://github.com/agilgur5/rollup-plugin-typescript2/actions/runs/2666782630) that tests pass on Windows now
- **EDIT**: and as double check, they pass here on this PR too