### PR TITLE
test: add initial watch mode test suite

### DIFF
--- a/__tests__/integration/errors.spec.ts
+++ b/__tests__/integration/errors.spec.ts
@@ -11,12 +11,12 @@ import * as helpers from "./helpers";
 jest.setTimeout(15000);
 
 const local = (x: string) => normalize(path.resolve(__dirname, x));
-const cacheRoot = local("__temp/errors/rpt2-cache"); // don't use the one in node_modules
+const testDir = local("__temp/errors");
 
 afterAll(async () => {
   // workaround: there seems to be some race condition causing fs.remove to fail, so give it a sec first (c.f. https://github.com/jprichardson/node-fs-extra/issues/532)
   await new Promise(resolve => setTimeout(resolve, 1000));
-  await fs.remove(cacheRoot);
+  await fs.remove(testDir);
 });
 
 async function genBundle(relInput: string, extraOpts?: RPT2Options, onwarn?: Mock) {
@@ -24,7 +24,7 @@ async function genBundle(relInput: string, extraOpts?: RPT2Options, onwarn?: Moc
   return helpers.genBundle({
     input,
     tsconfig: local("fixtures/errors/tsconfig.json"),
-    cacheRoot,
+    testDir,
     extraOpts: { include: [input], ...extraOpts }, // only include the input itself, not other error files (to only generate types and type-check the one file)
     onwarn,
   });
@@ -32,13 +32,13 @@ async function genBundle(relInput: string, extraOpts?: RPT2Options, onwarn?: Moc
 
 test("integration - tsconfig errors", async () => {
   // TODO: move to parse-tsconfig unit tests?
-  expect(genBundle("semantic.ts", {
+  await expect(genBundle("semantic.ts", {
     tsconfig: "non-existent-tsconfig",
   })).rejects.toThrow("rpt2: failed to open 'non-existent-tsconfig'");
 });
 
 test("integration - semantic error", async () => {
-  expect(genBundle("semantic.ts")).rejects.toThrow("Type 'string' is not assignable to type 'number'.");
+  await expect(genBundle("semantic.ts")).rejects.toThrow("Type 'string' is not assignable to type 'number'.");
 });
 
 test("integration - semantic error - abortOnError: false / check: false", async () => {
@@ -55,21 +55,21 @@ test("integration - semantic error - abortOnError: false / check: false", async 
   expect(onwarn).toBeCalledTimes(1);
 });
 
-test("integration - syntax error", () => {
-  expect(genBundle("syntax.ts")).rejects.toThrow("';' expected.");
+test("integration - syntax error", async () => {
+  await expect(genBundle("syntax.ts")).rejects.toThrow("';' expected.");
 });
 
-test("integration - syntax error - abortOnError: false / check: false", () => {
+test("integration - syntax error - abortOnError: false / check: false", async () => {
   const onwarn = jest.fn();
   const err = "Unexpected token (Note that you need plugins to import files that are not JavaScript)";
-  expect(genBundle("syntax.ts", { abortOnError: false }, onwarn)).rejects.toThrow(err);
-  expect(genBundle("syntax.ts", { check: false }, onwarn)).rejects.toThrow(err);
+  await expect(genBundle("syntax.ts", { abortOnError: false }, onwarn)).rejects.toThrow(err);
+  await expect(genBundle("syntax.ts", { check: false }, onwarn)).rejects.toThrow(err);
 });
 
 const typeOnlyIncludes = ["**/import-type-error.ts", "**/type-only-import-with-error.ts"];
 
-test("integration - type-only import error", () => {
-  expect(genBundle("import-type-error.ts", {
+test("integration - type-only import error", async () => {
+  await expect(genBundle("import-type-error.ts", {
     include: typeOnlyIncludes,
   })).rejects.toThrow("Property 'nonexistent' does not exist on type 'someObj'.");
 });

--- a/__tests__/integration/fixtures/no-errors/index.ts
+++ b/__tests__/integration/fixtures/no-errors/index.ts
@@ -2,6 +2,9 @@ export function sum(a: number, b: number) {
   return a + b;
 }
 
+import { difference } from "./some-import";
+export const diff2 = difference; // add an alias so that this file has to change when the import does (to help test cache invalidation etc)
+
 export { difference } from "./some-import"
 export type { num } from "./type-only-import"
 

--- a/__tests__/integration/helpers.ts
+++ b/__tests__/integration/helpers.ts
@@ -1,31 +1,39 @@
-import { rollup, RollupOptions, OutputAsset } from "rollup";
+import { rollup, watch, RollupOptions, OutputOptions, OutputAsset, RollupWatcher } from "rollup";
+import * as path from "path";
 
 import rpt2, { RPT2Options } from "../../src/index";
 
 type Params = {
   input: string,
   tsconfig: string,
-  cacheRoot: string,
+  testDir: string,
   extraOpts?: RPT2Options,
   onwarn?: RollupOptions['onwarn'],
 };
 
-export async function genBundle ({ input, tsconfig, cacheRoot, extraOpts, onwarn }: Params) {
-  const bundle = await rollup({
+function createInput ({ input, tsconfig, testDir, extraOpts, onwarn }: Params) {
+  return {
     input,
     plugins: [rpt2({
       tsconfig,
-      cacheRoot,
+      cacheRoot: `${testDir}/rpt2-cache`, // don't use the one in node_modules
       ...extraOpts,
     })],
     onwarn,
-  });
+  }
+}
 
-  const esm = await bundle.generate({
-    file: "./dist/index.js",
+function createOutput (testDir: string): OutputOptions {
+  return {
+    file: path.resolve(`${testDir}/dist/index.js`), // put outputs in temp test dir
     format: "esm",
     exports: "named",
-  });
+  }
+}
+
+export async function genBundle (inputArgs: Params) {
+  const bundle = await rollup(createInput(inputArgs));
+  const esm = await bundle.generate(createOutput(inputArgs.testDir));
 
   // Rollup has some deprecated properties like `get isAsset`, so enumerating them with, e.g. `.toEqual`, causes a bunch of warnings to be output
   // delete the `isAsset` property for (much) cleaner logs
@@ -38,4 +46,29 @@ export async function genBundle ({ input, tsconfig, cacheRoot, extraOpts, onwarn
   }
 
   return esm;
+}
+
+/** wrap Listener interface in a Promise */
+export function watchEnd (watcher: RollupWatcher) {
+  return new Promise<void>((resolve, reject) => {
+    watcher.on("event", event => {
+      if ("result" in event)
+        event.result?.close(); // close all bundles
+
+      if (event.code === "END")
+        resolve();
+      else if (event.code === "ERROR")
+        reject(event.error);
+    });
+  });
+}
+
+export async function watchBundle (inputArgs: Params) {
+  const watcher = watch({
+    ...createInput(inputArgs),
+    output: createOutput(inputArgs.testDir),
+  });
+
+  await watchEnd(watcher); // wait for build to end before returning, similar to genBundle
+  return watcher;
 }

--- a/__tests__/integration/no-errors.spec.ts
+++ b/__tests__/integration/no-errors.spec.ts
@@ -9,15 +9,15 @@ import * as helpers from "./helpers";
 jest.setTimeout(15000);
 
 const local = (x: string) => path.resolve(__dirname, x);
-const cacheRoot = local("__temp/no-errors/rpt2-cache"); // don't use the one in node_modules
+const testDir = local("__temp/no-errors");
 
-afterAll(() => fs.remove(cacheRoot));
+afterAll(() => fs.remove(testDir));
 
 async function genBundle(relInput: string, extraOpts?: RPT2Options) {
   return helpers.genBundle({
     input: local(`fixtures/no-errors/${relInput}`),
     tsconfig: local("fixtures/no-errors/tsconfig.json"),
-    cacheRoot,
+    testDir,
     extraOpts,
   });
 }

--- a/__tests__/integration/watch.spec.ts
+++ b/__tests__/integration/watch.spec.ts
@@ -1,0 +1,79 @@
+import { jest, beforeAll, afterAll, test, expect } from "@jest/globals";
+import * as path from "path";
+import * as fs from "fs-extra";
+
+import { RPT2Options } from "../../src/index";
+import * as helpers from "./helpers";
+
+// increase timeout to 15s for whole file since CI occassionally timed out -- these are integration and cache tests, so longer timeout is warranted
+jest.setTimeout(15000);
+
+const local = (x: string) => path.resolve(__dirname, x);
+const testDir = local("__temp/watch");
+const fixtureDir = `${testDir}/fixtures`;
+
+beforeAll(async () => {
+  await fs.ensureDir(fixtureDir);
+  // copy the dir to not interfere with other parallel tests since we need to change files for watch mode
+  // note we're copying the root fixture dir bc we need the _base_ tsconfig too. maybe optimize in the future or use the other fixtures?
+  await fs.copy(local("fixtures"), fixtureDir);
+});
+afterAll(() => fs.remove(testDir));
+
+async function watchBundle(input: string, extraOpts?: RPT2Options) {
+  return helpers.watchBundle({
+    input,
+    tsconfig: `${path.dirname(input)}/tsconfig.json`, // use the tsconfig of whatever fixture we're in
+    testDir,
+    extraOpts,
+  });
+}
+
+test("integration - watch", async () => {
+  const srcPath = `${fixtureDir}/no-errors/index.ts`;
+  const importPath = `${fixtureDir}/no-errors/some-import.ts`;
+  const distDir = `${testDir}/dist`;
+  const distPath = `${testDir}/dist/index.js`;
+  const decPath = `${distDir}/index.d.ts`;
+  const decMapPath = `${decPath}.map`;
+  const filesArr = [
+    "index.js",
+    "index.d.ts",
+    "index.d.ts.map",
+    "some-import.d.ts",
+    "some-import.d.ts.map",
+    "type-only-import.d.ts",
+    "type-only-import.d.ts.map",
+  ];
+
+  const watcher = await watchBundle(srcPath);
+
+  const files = await fs.readdir(distDir);
+  expect(files).toEqual(expect.arrayContaining(filesArr));
+  expect(files.length).toBe(filesArr.length); // no other files
+
+  // save content to test against later
+  const dist = await fs.readFile(distPath, "utf8");
+  const dec = await fs.readFile(decPath, "utf8");
+  const decMap = await fs.readFile(decMapPath, "utf8");
+
+  // modify an imported file -- this should cause it and index to change
+  await fs.writeFile(importPath, "export const difference = 2", "utf8");
+  await helpers.watchEnd(watcher);
+
+  // should have same structure, since names haven't changed and dist hasn't been cleaned
+  const files2 = await fs.readdir(distDir);
+  expect(files2).toEqual(expect.arrayContaining(filesArr));
+  expect(files2.length).toBe(filesArr.length); // no other files
+
+  // should have different content now though
+  expect(dist).not.toEqual(await fs.readFile(distPath, "utf8"));
+  expect(dec).not.toEqual(await fs.readFile(decPath, "utf8"));
+  expect(decMap).not.toEqual(await fs.readFile(decMapPath, "utf8"));
+
+  // modify an imported file to cause a semantic error
+  await fs.writeFile(importPath, "export const difference = nonexistent", "utf8")
+  await expect(helpers.watchEnd(watcher)).rejects.toThrow("Cannot find name 'nonexistent'.");
+
+  await watcher.close();
+});


### PR DESCRIPTION
## Summary

Creates a test harness/structure for [watch mode](https://rollupjs.org/guide/en/#rollupwatch) tests and adds an initial test suite to it
- Built on top of #371 and #384
- Follow-up to https://github.com/ezolenko/rollup-plugin-typescript2/pull/371#issuecomment-1174339120

## Details

- test starting watch mode, changing a file, and adding a semantic error
  - put this in a separate file as it has its own complexity to deal with (see below)
    - initially put it inside `no-errors`, but it got pretty confusing; this structure is a good bit simpler
    - refactored this a couple times actually

- add two watch mode helpers
  - `watchBundle` is very similar to `genBundle` but with some watch mode nuances (like returning a watcher)
  - `watchEnd` is a bit complicated async wrapper around a listener interface to make imperative testing simpler
  - refactor: abstract out `createInput` and `createOutput` to be used in both `genBundle` and `watchBundle`
    - refactor: make sure `dist` output gets put into a temp test dir
      - the previous config made it output into rpt2's `dist` dir, since `cwd` is project root (when running tests from project root)
      - the Rollup API's `watch` func always writes out; can't just test in-memory like with `bundle.generate`
        - so the `dist` dir becomes relevant as such
      - refactor: pass in a temp `testDir` instead of the `cacheRoot`
        - we can derive the `cacheRoot` and the `dist` output from `testDir`
        - also improve test clean-up by removing `testDir` at the end, not just the `cacheRoot` dir inside it
        - `testDir` is the same var used in the unit tests to define a temp dir for testing

- change the `no-errors` fixture a tiny bit so that changing the import causes it to change too

- this ended up being fairly complex due to having to handle lots of async and parallelism
  - parallel testing means fixtures have to be immutable, but watch mode needs to modify files
    - ended up copying fixtures to a temp dir where I could modify them
  - async events are all over here
    - had to convert a callback listener interface to async too, which was pretty confusing
      - and make sure the listener and bundles got properly closed too so no leaky tests
    - apparently `expect.rejects.toThrow` can return a Promise too, so missed this error for a while
      - refactor: make sure the error spec awaits too (though I think the errors _happen_ to throw synchronously there)
  - and also found a number of bugs while attempting to test cache invalidation within watch mode
    - thought it was a natural place to test since watch mode testing needs to modify files anyway
    - had to trace a bunch to figure out why some code paths weren't being covered -- see below section
  - testing Rollup watch within Jest watch also causes Jest to re-run a few times
    - I imagine double, overlapping watchers are confusing each other
    - might need to disable these tests when using Jest watch
  - high complexity async + parallel flows makes it pretty confusing to debug, so this code needs to be "handled with care"
    - also this high complexity was even harder to debug when I'm having migraines (which is most of the time, unfortunately)
      - hence why it took me a bit to finally make a PR for this small amount of code; the code was ok, the debugging was not too fun
        - that and I just didn't have time to make the PR for a bit / investigate the bugs below 

## Found several bugs

Per above, in the process of writing this, I discovered lots of bugs with watch mode itself as well as cache invalidation during watch mode. This took some tracing to figure out, so see this annotated trace log I manually created:

<details>
  <summary> Trace log: </summary>
  
```text
❯ npm run test:coverage -- watch

> rollup-plugin-typescript2@0.32.2 test:coverage
> jest --coverage "watch"

  console.log
    options:

      at Object.log (src/index.ts:95:12)

  \\\\\ this is only called once! /////
  console.log
    tscache constructor:

      at new log (src/tscache.ts:116:11)

  console.log
    cache.match:

      at RollingCache.log [as match] (src/rollingcache.ts:45:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/index.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/index.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/index.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/some-import.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/some-import.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/some-import.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    buildEnd:

      at Object.log (src/index.ts:257:12)
          at async Promise.all (index 0)

  \\\\\ walkTree is called, even though this is the first run, so there is no need to call it again /////
  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/index.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  \\\\\ dirty + ambientTypesDirty but this is the first run -- these were just written /////
  console.log
    isDirty: 
      checkImports: true
      ambientTypesDirty: true
      id: /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/index.ts
      label:  { dirty: true }

      at TsCache.log [as isDirty] (src/tscache.ts:299:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/index.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    isDirty: 
      checkImports: true
      ambientTypesDirty: true
      id: /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/index.ts
      label:  { dirty: true }

      at TsCache.log [as isDirty] (src/tscache.ts:299:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/some-import.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    isDirty: 
      checkImports: true
      ambientTypesDirty: true
      id: /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/some-import.ts
      label:  { dirty: true }

      at TsCache.log [as isDirty] (src/tscache.ts:299:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/some-import.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    isDirty: 
      checkImports: true
      ambientTypesDirty: true
      id: /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/some-import.ts
      label:  { dirty: true }

      at TsCache.log [as isDirty] (src/tscache.ts:299:11)

  \\\\\ options called again, but tscache's constructor wasn't! this also means that all caches were rolled and not reset! /////
  console.log
    options:

      at Object.log (src/index.ts:95:12)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/index.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/index.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/index.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/some-import.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/some-import.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/some-import.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    buildEnd:

      at Object.log (src/index.ts:257:12)
          at async Promise.all (index 0)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/index.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/index.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/some-import.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

  console.log
    cache: 
      id:  /rollup-plugin-typescript2/__tests__/integration/__temp/watch/fixtures/no-errors/some-import.ts

      at TsCache.log [as getCached] (src/tscache.ts:255:11)

 PASS  __tests__/integration/watch.spec.ts (6.672 s)
  ✓ integration - watch (2931 ms)

----------------------------|---------|----------|---------|---------|------------------------------------------------------------------------------------
File                        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s                                                                  
----------------------------|---------|----------|---------|---------|------------------------------------------------------------------------------------
All files                   |   71.52 |    45.09 |   67.79 |   73.26 |                                                                                    
 check-tsconfig.ts          |      80 |       25 |     100 |      80 | 10                                                                                 
 context.ts                 |    61.9 |    26.66 |   66.66 |      60 | 28-37,44,51                                                                        
 diagnostics-format-host.ts |      75 |      100 |   33.33 |   85.71 | 10                                                                                 
 get-options-overrides.ts   |   57.89 |     37.5 |   22.22 |   66.66 | 36,43-51,61-62,67-68                                                               
 host.ts                    |   77.19 |    69.23 |   91.66 |      74 | 21-22,52,70-87                                                                     
 index.ts                   |   79.48 |    55.26 |   58.33 |   86.11 | 62,114,117,135,150,162,179,203-207,218,240-241,262-266,284,293,302,320,324,330-332 
 parse-tsconfig.ts          |   88.88 |    64.28 |     100 |   88.88 | 18,28,35-36                                                                        
 print-diagnostics.ts       |   17.39 |        0 |      50 |   17.39 | 14-43                                                                              
 rollingcache.ts            |   79.48 |       60 |    87.5 |   79.48 | 47-48,54-63,72,80                                                                  
 rollupcontext.ts           |      28 |        0 |      20 |   18.18 | 14-49                                                                              
 tscache.ts                 |   71.72 |       45 |   85.29 |   70.14 | 66,82-96,122-123,154-177,194-195,201,253,261-270,302,305,310-326                   
 tslib.ts                   |      80 |      100 |     100 |      80 | 18-19                                                                              
 tsproxy.ts                 |     100 |      100 |     100 |     100 |                                                                                    
----------------------------|---------|----------|---------|---------|------------------------------------------------------------------------------------
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
Snapshots:   0 total
Time:        6.89 s, estimated 7 s
Ran all test suites matching /watch/i.
```

</details>


Per the annotations, there are a few bugs:
1. `walkTree` seems entirely unnecessary: it duplicates the existing type-checks
    1. I started writing a test to show this as well; if `walkTree` uses `RollupContext` instead of `ConsoleContext` we get duplicate warnings in the tests when using `abortOnError: false`.
1. The `tscache` constructor is only called once since it's created on plugin init and not in the `options` hook
    1. This means it's never reset in watch mode:
        1. That means that once it's rolled after the first build, it's never reset, so the cache effectively is only used for the first build on watch
            1. Using the [`closeWatcher` hook](https://rollupjs.org/guide/en/#closewatcher) to roll caches in watch mode instead of during `buildEnd` may be a workaround for this
        1. That means ambient types are never re-checked as well
    1. Note that this problem existed even before my cache refactors
        1. Those didn't change any actual functionality after all
        1. And I double-checked after this as well, [`init` was `private`](https://github.com/ezolenko/rollup-plugin-typescript2/blob/9ea15ceceed92cee123222404d850a397bf9f21c/src/tscache.ts#L304) before and `clean` was only called [when `pluginOptions.clean`](https://github.com/ezolenko/rollup-plugin-typescript2/blob/9ea15ceceed92cee123222404d850a397bf9f21c/src/index.ts#L132)
1. Similar to above, there may be problems (and optimizations to be made) as not all plugin vars are reset during the `options` hook in watch mode nor during the `watchChange` hook
    1. possible optimization related to #177 would be to re-use the TS [`DocumentRegistry`](https://github.com/microsoft/TypeScript/wiki/Using-the-Language-Service-API#document-registry) between watch cycles instead of resetting it in the `options` hook
    1. thought about `noErrors` not being reset, but that's only used when _not_ in watch mode, so maybe there aren't as many issues?
1. Despite having a test here that checks for cache invalidation on `checkImports`, the coverage report shows that the imports are never checked in watch mode (at least)
    1. Per the trace annotations, this seems to be because on the very first write, nodes and ambient types are marked as `dirty`. Since, in the current buggy watch mode, these are never reset (per above), they will always be `dirty` if starting from an empty / clean cache.
        1. Need to test starting from a non-empty cache in both watch and non-watch; hopefully the problem is only when starting fresh, which means fixing the lack of reset during watch mode above may fix this too. If not, the cache may be dirty the vast majority of the time; that coupled with the cache rolling after only 1 run may make it quite inefficient (and it's already more FS intensive than `noCache` mode, with I/O / FS being a general bottleneck to watch out for).
 
 
Related: Since I manually wrote debug log traces to track these down, it might be good to straight up add tracing / output a trace in debug verbosity, whether via library, runtime-native, or other. This could potentially obviate the need for debug logging as well and be a very powerful debugging / telemetry tool.