### PR TITLE
docs: clarify `clean: true` and default `include`

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,15 +144,17 @@ See [#108](https://github.com/ezolenko/rollup-plugin-typescript2/issues/108)
 
 * `clean`: false
 
-	Set to true for clean build (wipes out cache on every build).
+	Set to true to disable the cache and do a clean build.
+	This also wipes any existing cache.
 
 * `cacheRoot`: `node_modules/.cache/rollup-plugin-typescript2`
 
-	Path to cache. Defaults to a folder in node_modules.
+	Path to cache.
+	Defaults to a folder in `node_modules`.
 
 * `include`: `[ "*.ts+(|x)", "**/*.ts+(|x)" ]`
 
-	By default passes all .ts files through typescript compiler.
+	By default compiles all `.ts` and `.tsx` files with TypeScript.
 
 * `exclude`: `[ "*.d.ts", "**/*.d.ts" ]`
 


### PR DESCRIPTION
## Summary

Minor docs clarifications, fixes, and style consistency
- Follow-up to #375

## Details

- the docs for `clean` don't seem to have been updated after f15cb84dcc99a0bd20f3afce101c0991683010b6 (#68), which slightly changed how it works
- also clarify that "wipes out cache" means it deletes _all_ previous caches by saying "wipes any existing cache" instead

- fix the `include` default explanation to mention `.tsx` files as well, since the regex includes those
  - also add code backticks and capitalize TypeScript etc (guess I missed this option in my previous docs PRs? or I intentionally left it as a separate change a while ago...)

- also add code backticks around `node_modules` in `cacheRoot` as well while at it

- use non-rendered newlines between sentences for markdown style consistency
