### PR TITLE
optim(cache): don't check imports for syntactic diagnostics

### DIFF
--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -247,7 +247,8 @@ export class TsCache
 
 	private getDiagnostics(type: string, cache: ICache<IDiagnostics[]>, id: string, snapshot: tsTypes.IScriptSnapshot, check: () => tsTypes.Diagnostic[]): IDiagnostics[]
 	{
-		return this.getCached(cache, id, snapshot, true, () => convertDiagnostic(type, check()));
+		// don't need to check imports for syntactic diagnostics (per https://github.com/microsoft/TypeScript/wiki/Using-the-Language-Service-API#design-goals)
+		return this.getCached(cache, id, snapshot, type === "semantic", () => convertDiagnostic(type, check()));
 	}
 
 	private getCached<CacheType>(cache: ICache<CacheType>, id: string, snapshot: tsTypes.IScriptSnapshot, checkImports: boolean, convert: () => CacheType): CacheType


### PR DESCRIPTION
## Summary

Syntactic diagnostics are only per-file, so we don't need to `checkImports` in the cache's `isDirty` check for them

## Details

- Per the [TS LS Wiki](https://github.com/microsoft/TypeScript/wiki/Using-the-Language-Service-API#design-goals), syntactic diagnostics only need to parse the specific file in question
  - since syntax is independent of imports; imports only affect semantics

## References

- Just happened to finally realize this while reading the LS Wiki for #388 .
- Related to #369 ; that was a de-opt for `codeCache`, this is an optimization for `syntacticDiagnosticsCache`