### PR TITLE
refactor: move `generateRound = 0` to `buildEnd`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -196,8 +196,6 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 		transform(code, id)
 		{
-			generateRound = 0; // in watch mode transform call resets generate count (used to avoid printing too many copies of the same error messages)
-
 			if (!filter(id))
 				return undefined;
 
@@ -266,6 +264,8 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 		buildEnd(err)
 		{
+			generateRound = 0; // in watch mode, buildEnd resets generate count just before generateBundle for each output
+
 			if (err)
 			{
 				buildDone();


### PR DESCRIPTION
## Summary

Put `generateRound = 0` in `buildEnd` instead of `transform`
- Follow-up to the `buildEnd` refactor in #345

## Details

- since the `buildEnd` hook exists nowadays, we can just reset `generateRound` there, right before `generateBundle` is called for each output and increments it per output
- also modify the comment to account for this change and the fact that `buildEnd` exists and is used nowadays

## Review Notes

Note that `generateRound` is literally only used for logging purposes now, since the `buildEnd` refactor made it otherwise unneeded for its original purpose of not duplicating type-check errors between different outputs.
Could totally remove it as well 🤷 