### PR TITLE
refactor(cache): further condense `walkTree`

### DIFF
--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -188,13 +188,9 @@ export class TsCache
 	public walkTree(cb: (id: string) => void | false): void
 	{
 		if (alg.isAcyclic(this.dependencyTree))
-		{
-			alg.topsort(this.dependencyTree).forEach(id => cb(id));
-			return;
-		}
+			return alg.topsort(this.dependencyTree).forEach(id => cb(id));
 
 		this.context.info(yellow("import tree has cycles"));
-
 		this.dependencyTree.nodes().forEach(id => cb(id));
 	}
 


### PR DESCRIPTION
## Summary

Condense `walkTree` further to just 4 LoC
- Follow-up to #359 I guess

## Details

- `forEach` returns `void`, so we can just `return` it and condense the `if` a bit
