### PR TITLE
dx(cache): improve `clean` edge-case errors with quotes

### DIFF
--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -161,14 +161,14 @@ export class TsCache
 			/* istanbul ignore if -- this is a safety check, but shouldn't happen when using a dedicated cache dir */
 			if (!e.startsWith(this.cachePrefix))
 			{
-				this.context.debug(`skipping cleaning ${dir} as it does not have prefix ${this.cachePrefix}`);
+				this.context.debug(`skipping cleaning '${dir}' as it does not have prefix '${this.cachePrefix}'`);
 				return;
 			}
 
 			/* istanbul ignore if -- this is a safety check, but should never happen in normal usage */
 			if (!fs.statSync(dir).isDirectory)
 			{
-				this.context.debug(`skipping cleaning ${dir} as it is not a directory`);
+				this.context.debug(`skipping cleaning '${dir}' as it is not a directory`);
 				return;
 			}
 


### PR DESCRIPTION
## Summary

Add quotes around vars in error messages in the cache's `clean` method
- Follow-up to #358
  - Note that the error messages beforehand _also_ weren't quoted
   
## Details

- follows the style of most of the other errors in the codebase
  - when referencing a variable, file path, etc, put quotes around it in the output
    - so it's easier to distinguish in the log
