### PR TITLE
dx: be more explicit with `emitSkipped` error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -216,7 +216,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 					// always checking on fatal errors, even if options.check is set to false
 					typecheckFile(id, snapshot, contextWrapper);
 					// since no output was generated, aborting compilation
-					this.error(red(`failed to transpile '${id}'`));
+					this.error(red(`Emit skipped for '${id}'. See https://github.com/microsoft/TypeScript/issues/49790 for potential reasons why this may occur`));
 				}
 
 				const references = getAllReferences(id, snapshot, parsedConfig.options);


### PR DESCRIPTION
## Summary

Provide a bit more details when erroring on `emitSkipped` and link to my TS issue since this is unfortunately undocumented
- See my upstream issue: https://github.com/microsoft/TypeScript/issues/49790
- Related to #254, #264, https://github.com/ezolenko/rollup-plugin-typescript2/pull/371#issuecomment-1174339120

## Details

- a few issues have reported that "failed to transpile" is a vague / confusing error
  - and `emitSkipped` actually _doesn't_ mean that it failed to transpile, as, in current versions of TS, it's not due to syntactic or semantic errors (c.f. https://github.com/microsoft/TypeScript/issues/2290#issuecomment-78203910, which is linked in my upstream issue)
- so explicitly say "Emit skipped" instead, which is slightly less vague, in that it can actually be used as a search term
  - and provide a link to my TS issue that lists some reasons why `emitSkipped` occurs, since this is unfortunately otherwise undocumented by TS
    - in the future, hopefully that issue will be resolved and we'll be able to give better or more specific error messages, but for now this is probably the best we can do due to its undocumented nature, unfortunately
