### PR TITLE
refactor(test): use more specific checks in `check-tsconfig` spec

### DIFF
--- a/__tests__/check-tsconfig.spec.ts
+++ b/__tests__/check-tsconfig.spec.ts
@@ -11,18 +11,23 @@ const defaultConfig = { fileNames: [], errors: [], options: {} };
 test("checkTsConfig", () => {
 	expect(() => checkTsConfig({
 		...defaultConfig,
-		options: { module: ts.ModuleKind.None },
-	})).toThrow(
-		"Incompatible tsconfig option. Module resolves to 'None'. This is incompatible with Rollup, please use",
-	);
-
-	expect(checkTsConfig({
-		...defaultConfig,
 		options: { module: ts.ModuleKind.ES2015 },
-	})).toBeFalsy();
+	})).not.toThrow();
 
-	expect(checkTsConfig({
+	expect(() => checkTsConfig({
+		...defaultConfig,
+		options: { module: ts.ModuleKind.ES2020 },
+	})).not.toThrow();
+
+	expect(() => checkTsConfig({
 		...defaultConfig,
 		options: { module: ts.ModuleKind.ESNext },
-	})).toBeFalsy();
+	})).not.toThrow();
+});
+
+test("checkTsConfig - errors", () => {
+	expect(() => checkTsConfig({
+		...defaultConfig,
+		options: { module: ts.ModuleKind.None },
+	})).toThrow("Incompatible tsconfig option. Module resolves to 'None'. This is incompatible with Rollup, please use");
 });


### PR DESCRIPTION
## Summary

Be more precise with the checks in `check-tsconfig.spec.ts` and reorder things a bit
- `check-tsconfig.spec.ts` should now match the structure of `parse-tsconfig.spec.ts` from #397
- Follow-up to #321 

## Details

- `toBeFalsy()` was a bit imprecise and always felt as such, especially since `checkTsConfig` returns `void`
  - so instead check that it doesn't throw, which matches the test _intent_

- reorder the tests a bit to match existing test style: non-errors first, then errors
  - and separating into two different test blocks parallelizes them as well

- also add an ES2020 check as well
  - follow-up to eb1dd17babde0b22e9540b12e671eb56d9d6bce0 and #376