### PR TITLE
test: 100% coverage for `tslib.ts` (error case)

### DIFF
--- a/__tests__/tslib.spec.ts
+++ b/__tests__/tslib.spec.ts
@@ -1,9 +1,19 @@
-import { test, expect } from "@jest/globals";
+import { test, expect, jest } from "@jest/globals";
 import * as fs from "fs-extra";
 
-import { tslibVersion, tslibSource } from "../src/tslib";
+(global as any).console = { warn: jest.fn() };
+
+// the error case _must_ come first because order matters for module mocks
+test("tslib - errors", async () => {
+	jest.mock("tslib/package.json", () => undefined); // mock the module subpath bc we actually never import "tslib" directly. module mocks only work on exact match
+	await expect(import("../src/tslib")).rejects.toThrow();
+	expect(console.warn).toBeCalledTimes(1);
+});
 
 test("tslib", async () => {
+	jest.unmock("tslib/package.json");
+
+	const { tslibVersion, tslibSource } = await import("../src/tslib");
 	expect(tslibVersion).toEqual(require("tslib/package.json").version);
 
 	const tslibES6 = await fs.readFile(require.resolve("tslib/tslib.es6.js"), "utf8");


### PR DESCRIPTION
## Summary

Get to 100% coverage of `tslib.ts` by adding a check for error case
- Follow-up to #321

## Details

- use Jest's [module mocks](https://jestjs.io/docs/jest-object#jestmockmodulename-factory-options) to test the error case of `tslib.ts` when `tslib` fails to import
  - this took a bit of work to figure out bc, per the in-line comments, the ordering and module subpath were both _required_
    - it was pretty confusing for a while until I realized what might be going wrong
