### PR TITLE
clean: remove redundant `generateRound === 0` check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -111,26 +111,24 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			watchMode = process.env.ROLLUP_WATCH === "true" || !!this.meta.watchMode; // meta.watchMode was added in 2.14.0 to capture watch via Rollup API (i.e. no env var) (c.f. https://github.com/rollup/rollup/blob/master/CHANGELOG.md#2140)
 			({ parsedTsConfig: parsedConfig, fileName: tsConfigPath } = parseTsConfig(context, pluginOptions));
 
-			if (generateRound === 0)
-			{
-				context.info(`typescript version: ${tsModule.version}`);
-				context.info(`tslib version: ${tslibVersion}`);
-				context.info(`rollup version: ${this.meta.rollupVersion}`);
+			// print out all versions and configurations
+			context.info(`typescript version: ${tsModule.version}`);
+			context.info(`tslib version: ${tslibVersion}`);
+			context.info(`rollup version: ${this.meta.rollupVersion}`);
 
-				context.info(`rollup-plugin-typescript2 version: $RPT2_VERSION`);
-				context.debug(() => `plugin options:\n${JSON.stringify(pluginOptions, (key, value) => key === "typescript" ? `version ${(value as typeof tsModule).version}` : value, 4)}`);
-				context.debug(() => `rollup config:\n${JSON.stringify(rollupOptions, undefined, 4)}`);
-				context.debug(() => `tsconfig path: ${tsConfigPath}`);
+			context.info(`rollup-plugin-typescript2 version: $RPT2_VERSION`);
+			context.debug(() => `plugin options:\n${JSON.stringify(pluginOptions, (key, value) => key === "typescript" ? `version ${(value as typeof tsModule).version}` : value, 4)}`);
+			context.debug(() => `rollup config:\n${JSON.stringify(rollupOptions, undefined, 4)}`);
+			context.debug(() => `tsconfig path: ${tsConfigPath}`);
 
-				if (pluginOptions.objectHashIgnoreUnknownHack)
-					context.warn(() => `${yellow("You are using 'objectHashIgnoreUnknownHack' option")}. If you enabled it because of async functions, try disabling it now.`);
+			if (pluginOptions.objectHashIgnoreUnknownHack)
+				context.warn(() => `${yellow("You are using 'objectHashIgnoreUnknownHack' option")}. If you enabled it because of async functions, try disabling it now.`);
 
-				if (pluginOptions.rollupCommonJSResolveHack)
-					context.warn(() => `${yellow("You are using 'rollupCommonJSResolveHack' option")}. This is no longer needed, try disabling it now.`);
+			if (pluginOptions.rollupCommonJSResolveHack)
+				context.warn(() => `${yellow("You are using 'rollupCommonJSResolveHack' option")}. This is no longer needed, try disabling it now.`);
 
-				if (watchMode)
-					context.info(`running in watch mode`);
-			}
+			if (watchMode)
+				context.info(`running in watch mode`);
 
 			filter = createFilter(context, pluginOptions, parsedConfig);
 


### PR DESCRIPTION
## Summary

Removes the `if (generateRound === 0)` check in the `options` hook as it is redundant / unnecessary
- Related to, but independent of, #390

## Details

- when `options` is called, `generateRound` should have already been reset to `0`, so this is redundant / unnecessary
  - `options` is only called once per watch cycle
  - `options` is also an `input` hook, not an `output` hook, i.e. it's only called once for _all_ outputs, _not_ per each output
    - `generateRound` only tracks the output round

- this might be leftover historical remnants prior to Rollup officially separating `output` hooks, but even before then, it should only have been called once for _all_ outputs
  - since, per the Rollup API, it's only called during `rollup.rollup` and not during `bundle.generate` etc
  - c.f. old docs https://github.com/rollup/rollup/blob/v1.18.0/docs/05-plugin-development.md#options
  - it's possible this is _even older_, but I couldn't find plugin docs for Rollup pre-1.0 to try to confirm against
