### PR TITLE
test(cache): ignore coverage for corrupted cache check

### DIFF
--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -268,7 +268,7 @@ export class TsCache
 				cache.write(hash, data);
 				return data;
 			}
-			else
+			else /* istanbul ignore next -- should only happen when corrupted cache */
 				this.context.warn(yellow("    cache broken, discarding"));
 		}
 


### PR DESCRIPTION
## Summary

Add an `istanbul-ignore` statement to the `else` check in the cache regarding corrupted or otherwise "broken" cache
- Related to https://github.com/ezolenko/rollup-plugin-typescript2/pull/358#issuecomment-1159295541

## Details

- similar to the other safety checks in `clean`, this won't be hit during normal usage
