### PR TITLE
refactor(diagnostics): simplify some conditionals

### DIFF
--- a/src/print-diagnostics.ts
+++ b/src/print-diagnostics.ts
@@ -34,13 +34,11 @@ export function printDiagnostics(context: IContext, diagnostics: IDiagnostics[],
 		const type = diagnostic.type + " ";
 
 		if (pretty)
-			print.call(context, `${diagnostic.formatted}`);
-		else
-		{
-			if (diagnostic.fileLine !== undefined)
-				print.call(context, `${diagnostic.fileLine}: ${type}${category} TS${diagnostic.code}: ${color(diagnostic.flatMessage)}`);
-			else
-				print.call(context, `${type}${category} TS${diagnostic.code}: ${color(diagnostic.flatMessage)}`);
-		}
+			return print.call(context, `${diagnostic.formatted}`);
+
+		if (diagnostic.fileLine !== undefined)
+			return print.call(context, `${diagnostic.fileLine}: ${type}${category} TS${diagnostic.code}: ${color(diagnostic.flatMessage)}`);
+
+		return print.call(context, `${type}${category} TS${diagnostic.code}: ${color(diagnostic.flatMessage)}`);
 	});
 }


### PR DESCRIPTION
## Summary

Simplify some conditionals in `print-diagnostics` by reducing nesting
- Follow-up / related to https://github.com/ezolenko/rollup-plugin-typescript2/pull/335#issuecomment-1151365993

## Details

- reduce the complexity of the code by decreasing the amount of nesting

- note that `print` returns `void` anyway, so calling it within the `return` statement doesn't change anything
  - and this is within a `void` `forEach` at that too