### PR TITLE
test: add `print-diagnostics` spec 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,6 @@ Use the [standard GitHub process](https://docs.github.com/en/pull-requests/colla
 1. `npm run test:coverage` to run tests and output a test coverage report
 
 While this repo now has an assortment of unit tests and integration tests, it still needs more integration tests with various scenarios and expected outcomes.
-Test coverage improvements for existing files and untested files is needed as well.
 
 ### Building and Self-Build
 

--- a/__tests__/print-diagnostics.spec.ts
+++ b/__tests__/print-diagnostics.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from "@jest/globals";
+import * as ts from "typescript";
+import { red } from "colors/safe";
+
+import { makeContext } from "./fixtures/context";
+import { setTypescriptModule } from "../src/tsproxy";
+import { printDiagnostics } from "../src/print-diagnostics";
+
+setTypescriptModule(ts);
+
+const diagnostic = {
+	flatMessage: "Compiler option 'include' requires a value of type Array.",
+	formatted: "\x1B[91merror\x1B[0m\x1B[90m TS5024: \x1B[0mCompiler option 'include' requires a value of type Array.\n",
+	category: ts.DiagnosticCategory.Error,
+	code: 5024,
+	type: 'config'
+};
+
+test("print-diagnostics - categories", () => {
+	const context = makeContext();
+
+	printDiagnostics(context, [diagnostic]);
+	expect(context.error).toHaveBeenLastCalledWith(diagnostic.formatted);
+
+	printDiagnostics(context, [{ ...diagnostic, category: ts.DiagnosticCategory.Warning } ]);
+	expect(context.warn).toHaveBeenLastCalledWith(diagnostic.formatted);
+
+	printDiagnostics(context, [{ ...diagnostic, category: ts.DiagnosticCategory.Suggestion } ]); // default case
+	expect(context.warn).toHaveBeenLastCalledWith(diagnostic.formatted);
+
+	printDiagnostics(context, [{ ...diagnostic, category: ts.DiagnosticCategory.Message } ]);
+	expect(context.info).toHaveBeenLastCalledWith(diagnostic.formatted);
+
+	// should match exactly, no more
+	expect(context.error).toBeCalledTimes(1);
+	expect(context.warn).toBeCalledTimes(2)
+	expect(context.info).toBeCalledTimes(1);
+	expect(context.debug).toBeCalledTimes(0);
+});
+
+test("print-diagnostics - formatting / style", () => {
+	const context = makeContext();
+	const category = "error"; // string version
+
+	printDiagnostics(context, [diagnostic], false);
+	expect(context.error).toHaveBeenLastCalledWith(`${diagnostic.type} ${category} TS${diagnostic.code}: ${red(diagnostic.flatMessage)}`);
+
+	const fileLine = "0"
+	printDiagnostics(context, [{ ...diagnostic, fileLine }], false);
+	expect(context.error).toHaveBeenLastCalledWith(`${fileLine}: ${diagnostic.type} ${category} TS${diagnostic.code}: ${red(diagnostic.flatMessage)}`);
+
+	// should match exactly, no more
+	expect(context.error).toBeCalledTimes(2);
+	expect(context.warn).toBeCalledTimes(0)
+	expect(context.info).toBeCalledTimes(0);
+	expect(context.debug).toBeCalledTimes(0);
+});


### PR DESCRIPTION
~**NOTE**: this is built on top of #404 as it uses the `context` changes made there. #404 is itself built on top of #397. As such, I've marked this PR as "Draft" until those PRs are merged.~
Rebased on top and marked as ready for review.

## Summary

Adds unit tests for all scenarios of `print-diagnostics.ts`
- Follow-up to #321

## Details

- test all the different categories and formattings
- full unit test coverage now! (except for `index`/`tscache`, which integration tests cover)
  - (since this is in "Draft" status right now, full coverage does also depend on #397 being merged)
