### PR TITLE
fix: handle all type-only imports by piping TS imports

### DIFF
--- a/__tests__/integration/errors.spec.ts
+++ b/__tests__/integration/errors.spec.ts
@@ -5,7 +5,7 @@ import { normalizePath as normalize } from "@rollup/pluginutils";
 import * as fs from "fs-extra";
 
 import { RPT2Options } from "../../src/index";
-import * as helpers from "./helpers";
+import { findName, genBundle as genBundleH } from "./helpers";
 
 // increase timeout to 15s for whole file since CI occassionally timed out -- these are integration and cache tests, so longer timeout is warranted
 jest.setTimeout(15000);
@@ -21,7 +21,7 @@ afterAll(async () => {
 
 async function genBundle(relInput: string, extraOpts?: RPT2Options, onwarn?: Mock) {
   const input = local(`fixtures/errors/${relInput}`);
-  return helpers.genBundle({
+  return genBundleH({
     input,
     tsconfig: local("fixtures/errors/tsconfig.json"),
     testDir,
@@ -41,10 +41,11 @@ test("integration - semantic error - abortOnError: false / check: false", async 
   const { output: output2 } = await genBundle("semantic.ts", { check: false }, onwarn);
   expect(output).toEqual(output2);
 
-  expect(output[0].fileName).toEqual("index.js");
-  expect(output[1].fileName).toEqual("semantic.d.ts");
-  expect(output[2].fileName).toEqual("semantic.d.ts.map");
-  expect(output.length).toEqual(3); // no other files
+  const files = ["index.js", "semantic.d.ts", "semantic.d.ts.map"];
+  files.forEach(file => {
+    expect(findName(output, file)).toBeTruthy();
+  });
+  expect(output.length).toEqual(files.length); // no other files
   expect(onwarn).toBeCalledTimes(1);
 });
 
@@ -80,11 +81,10 @@ test("integration - type-only import error - abortOnError: false / check: false"
   }, onwarn);
   expect(output).toEqual(output2);
 
-  expect(output[0].fileName).toEqual("index.js");
-  expect(output[1].fileName).toEqual("import-type-error.d.ts");
-  expect(output[2].fileName).toEqual("import-type-error.d.ts.map");
-  expect(output[3].fileName).toEqual("type-only-import-with-error.d.ts");
-  expect(output[4].fileName).toEqual("type-only-import-with-error.d.ts.map");
-  expect(output.length).toEqual(5); // no other files
+  const files = ["index.js", "import-type-error.d.ts", "import-type-error.d.ts.map", "type-only-import-with-error.d.ts.map", "type-only-import-with-error.d.ts.map"];
+  files.forEach(file => {
+    expect(findName(output, file)).toBeTruthy();
+  });
+  expect(output.length).toEqual(files.length); // no other files
   expect(onwarn).toBeCalledTimes(1);
 });

--- a/__tests__/integration/fixtures/no-errors.ts
+++ b/__tests__/integration/fixtures/no-errors.ts
@@ -1,0 +1,11 @@
+export const filesArr = [
+  "index.js",
+  "index.d.ts",
+  "index.d.ts.map",
+  "some-import.d.ts",
+  "some-import.d.ts.map",
+  "type-only-import.d.ts",
+  "type-only-import.d.ts.map",
+  "type-only-import-import.d.ts",
+  "type-only-import-import.d.ts.map",
+];

--- a/__tests__/integration/fixtures/no-errors/index.ts
+++ b/__tests__/integration/fixtures/no-errors/index.ts
@@ -6,6 +6,6 @@ import { difference } from "./some-import";
 export const diff2 = difference; // add an alias so that this file has to change when the import does (to help test cache invalidation etc)
 
 export { difference } from "./some-import"
-export type { num } from "./type-only-import"
+export type { num, num2 } from "./type-only-import"
 
 export { identity } from "./some-js-import"

--- a/__tests__/integration/fixtures/no-errors/type-only-import-import.ts
+++ b/__tests__/integration/fixtures/no-errors/type-only-import-import.ts
@@ -1,0 +1,1 @@
+export type numb = number;

--- a/__tests__/integration/fixtures/no-errors/type-only-import.ts
+++ b/__tests__/integration/fixtures/no-errors/type-only-import.ts
@@ -1,1 +1,4 @@
+import type { numb } from "./type-only-import-import";
+
 export type num = number;
+export type num2 = numb;

--- a/__tests__/integration/helpers.ts
+++ b/__tests__/integration/helpers.ts
@@ -1,4 +1,4 @@
-import { rollup, watch, RollupOptions, OutputOptions, OutputAsset, RollupWatcher } from "rollup";
+import { rollup, watch, RollupOptions, OutputOptions, RollupOutput, OutputAsset, RollupWatcher } from "rollup";
 import * as path from "path";
 
 import rpt2, { RPT2Options } from "../../src/index";
@@ -71,4 +71,9 @@ export async function watchBundle (inputArgs: Params) {
 
   await watchEnd(watcher); // wait for build to end before returning, similar to genBundle
   return watcher;
+}
+
+export function findName (output: RollupOutput['output'], name: string) {
+  // type-cast to simplify type-checking -- [0] is always chunk, rest are always asset in our case
+  return output.find(file => file.fileName === name) as OutputAsset;
 }

--- a/__tests__/integration/no-errors.spec.ts
+++ b/__tests__/integration/no-errors.spec.ts
@@ -1,11 +1,11 @@
 import { jest, afterAll, test, expect } from "@jest/globals";
 import * as path from "path";
 import * as fs from "fs-extra";
-import { OutputAsset } from "rollup";
 import { normalizePath as normalize } from "@rollup/pluginutils";
 
 import { RPT2Options } from "../../src/index";
-import * as helpers from "./helpers";
+import { filesArr } from "./fixtures/no-errors";
+import { findName, genBundle as genBundleH } from "./helpers";
 
 // increase timeout to 15s for whole file since CI occassionally timed out -- these are integration and cache tests, so longer timeout is warranted
 jest.setTimeout(15000);
@@ -17,7 +17,7 @@ const fixtureDir = local("fixtures/no-errors");
 afterAll(() => fs.remove(testDir));
 
 async function genBundle(relInput: string, extraOpts?: RPT2Options) {
-  return helpers.genBundle({
+  return genBundleH({
     input: `${fixtureDir}/${relInput}`,
     tsconfig: `${fixtureDir}/tsconfig.json`,
     testDir,
@@ -33,22 +33,31 @@ test("integration - no errors", async () => {
   const { output: outputWithCache } = await genBundle("index.ts");
   expect(output).toEqual(outputWithCache);
 
-  expect(output[0].fileName).toEqual("index.js");
-  expect(output[1].fileName).toEqual("index.d.ts");
-  expect(output[2].fileName).toEqual("index.d.ts.map");
-  expect(output[3].fileName).toEqual("some-import.d.ts");
-  expect(output[4].fileName).toEqual("some-import.d.ts.map");
-  expect(output[5].fileName).toEqual("type-only-import.d.ts");
-  expect(output[6].fileName).toEqual("type-only-import.d.ts.map");
-  expect(output.length).toEqual(7); // no other files
+  const files = filesArr;
+  files.forEach(file => {
+    expect(findName(output, file)).toBeTruthy();
+  });
+  expect(output.length).toEqual(files.length); // no other files
 
   // JS file should be bundled by Rollup, even though rpt2 does not resolve it (as Rollup natively understands ESM)
   expect(output[0].code).toEqual(expect.stringContaining("identity"));
 
   // declaration map sources should be correctly remapped (and not point to placeholder dir, c.f. https://github.com/ezolenko/rollup-plugin-typescript2/pull/221)
-  const decMapSources = JSON.parse((output[2] as OutputAsset).source as string).sources;
+  const decMap = findName(output, "index.d.ts.map");
+  const decMapSources = JSON.parse(decMap.source as string).sources;
   const decRelPath = normalize(path.relative(`${testDir}/dist`, `${fixtureDir}/index.ts`));
   expect(decMapSources).toEqual([decRelPath]);
+});
+
+test("integration - no errors - using files list", async () => {
+  const { output } = await genBundle("index.ts", { tsconfigOverride: { files: ["index.ts"] } });
+
+  // should still have the type-only import and type-only import import!
+  const files = filesArr;
+  files.forEach(file => {
+    expect(findName(output, file)).toBeTruthy();
+  });
+  expect(output.length).toEqual(files.length); // no other files
 });
 
 test("integration - no errors - no declaration maps", async () => {
@@ -58,11 +67,11 @@ test("integration - no errors - no declaration maps", async () => {
     clean: true,
   });
 
-  expect(output[0].fileName).toEqual("index.js");
-  expect(output[1].fileName).toEqual("index.d.ts");
-  expect(output[2].fileName).toEqual("some-import.d.ts");
-  expect(output[3].fileName).toEqual("type-only-import.d.ts");
-  expect(output.length).toEqual(4); // no other files
+  const files = filesArr.filter(file => !file.endsWith(".d.ts.map"));
+  files.forEach(file => {
+    expect(findName(output, file)).toBeTruthy();
+  });
+  expect(output.length).toEqual(files.length); // no other files
 });
 
 
@@ -88,12 +97,15 @@ test("integration - no errors - allowJs + emitDeclarationOnly", async () => {
     },
   });
 
-  expect(output[0].fileName).toEqual("index.js");
-  expect(output[1].fileName).toEqual("some-js-import.d.ts");
-  expect(output[2].fileName).toEqual("some-js-import.d.ts.map");
-  expect(output.length).toEqual(3); // no other files
+  const files = ["index.js", "some-js-import.d.ts", "some-js-import.d.ts.map"];
+  files.forEach(file => {
+    expect(findName(output, file)).toBeTruthy();
+  });
+  expect(output.length).toEqual(files.length); // no other files
 
   expect(output[0].code).toEqual(expect.stringContaining("identity"));
   expect(output[0].code).not.toEqual(expect.stringContaining("sum")); // no TS files included
-  expect("source" in output[1] && output[1].source).toEqual(expect.stringContaining("identity"));
+
+  const dec = findName(output, "some-js-import.d.ts");
+  expect(dec.source).toEqual(expect.stringContaining("identity"));
 });

--- a/__tests__/integration/watch.spec.ts
+++ b/__tests__/integration/watch.spec.ts
@@ -3,6 +3,7 @@ import * as path from "path";
 import * as fs from "fs-extra";
 
 import { RPT2Options } from "../../src/index";
+import { filesArr } from "./fixtures/no-errors";
 import * as helpers from "./helpers";
 
 // increase timeout to 15s for whole file since CI occassionally timed out -- these are integration and cache tests, so longer timeout is warranted
@@ -36,15 +37,6 @@ test("integration - watch", async () => {
   const distPath = `${testDir}/dist/index.js`;
   const decPath = `${distDir}/index.d.ts`;
   const decMapPath = `${decPath}.map`;
-  const filesArr = [
-    "index.js",
-    "index.d.ts",
-    "index.d.ts.map",
-    "some-import.d.ts",
-    "some-import.d.ts.map",
-    "type-only-import.d.ts",
-    "type-only-import.d.ts.map",
-  ];
 
   const watcher = await watchBundle(srcPath);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -209,7 +209,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 		async transform(code, id)
 		{
-			transformedFiles.add(id);
+			transformedFiles.add(id); // note: this does not need normalization as we only compare Rollup <-> Rollup, and not Rollup <-> TS
 
 			if (!filter(id))
 				return undefined;


### PR DESCRIPTION
~**NOTE**: this is built on top of #403 as it changes its code a bit. #403 is itself built on top of #386. As such, I've marked this PR as "Draft" until those PRs are merged.~
Rebased on top and marked as ready for review. (surprisingly clean rebase)

Also this might be the first time this repo has more open PRs than open issues 😮 

## Summary

Completely handle the long-standing issue of type-only imports
- Uses the solution I proposed in my root cause analysis in https://github.com/ezolenko/rollup-plugin-typescript2/issues/298#issuecomment-1146658442
- Fixes #7 as all type-only imports go through the `resolveId` hook now, which adds them to the cache (calls `cache().setDependency`)
- Fixes #211
  - And its various duplicates: fixes #24, fixes #106, fixes #409
- Fully fixes the most common issue that I mentioned in https://github.com/ezolenko/rollup-plugin-typescript2/pull/311#issuecomment-1115491161, type-only imports
- Related to #345
  - _That_ PR fixed #298 and the latter half of #254 for their specific use-cases as they happen to use `include` globs, but _this_ PR fixes it in all other scenarios as well (namely when using [`files`](https://www.typescriptlang.org/tsconfig#files) instead of `include` globs)

## Details

- `result.references` is populated by `ts.preProcessFile`; i.e. this is TS discovering all imports, instead of Rollup
  - TS's imports include type-only files as TS understands those (whereas they aren't emitted in the JS for Rollup to see, since, well, they produce no JS)
  - so we can pipe all these through Rollup's `this.resolve` and `this.load` to make them go through Rollup's `resolveId` -> `load` -> `transform` hooks
    - this makes sure that other plugins on the chain get to resolve/transform them as well
    - and it makes sure that we run the same code that we run on all other files on type-only ones too
      - for instance: adding declarations, type-checking, setting them as deps in the cache graph, etc
      - yay recursion!
        - also add check for circular references b/c of this recursion (which Rollup docs confirm is necessary, per in-line comment)
    - and Rollup ensures that there is no perf penalty if a regular file is processed this way either, as it won't save the hook results when it appears in JS (i.e. Rollup's module graph)
      - we are checking more files though, so that in and of itself means potential slowdown for better correctness

- add a test for this that uses a `tsconfig` `files` array, ensuring that the `include` workaround won't cover these type-only files
  - this test fails without the new code added to `index` in this commit
  - also add another file, `type-only-import-import`, to the `no-errors` fixture to ensure that we're not just checking imports one level deep, and actually going through type-only imports of type-only imports as well
    - the declaration check for this will fail if type-only imports are not handled recursively
      - an initial version of this fix that I had that didn't call `this.load` failed this check

- refactor(test): make the integration tests more resilient to output ordering changes
  - due to the eager calls to `this.load`, the ordering of declaration and declaration map outputs in the bundle changed
    - and bc TS's default ordering of imports seems to differ from Rollup's
  - note that this only changed the order of the "bundle output" object -- which Rollup doesn't guarantee ordering of anyway
    - all files are still in the bundle output and are still written to disk
    - for example, the `watch` tests did not rely on this ordering and as such did not need to change due to the ordering change
  - create a `findName` helper that will search the `output` array instead, ensuring that most ordering does not matter
    - we do still rely on `output[0]` being the bundled JS (ESM) file, however

- refactor(test): go through a `files` array for tests that check for multiple files instead of listing out each individual check
  - this makes the tests more resilient to fixture changes as well (i.e. addition / deletion of files)
  - create `no-errors.ts` that exports a list of files for this fixture
    - didn't need to do the same for `errors.ts` as of yet; may do so in the future though
    
## Review Notes

1. I double-checked that the [`transform` hook](https://github.com/rollup/rollup/blob/v1.18.0/docs/05-plugin-development.md#transform) could be async in the minimum Rollup version we support.
    - The in-line linked docs are from Rollup `v1.18.0` as I couldn't find a mention of async in the `CHANGELOG.md`.
  
1. This could be considered "breaking", but the bundle ordering should realistically not affect anyone (only tests that rely on ordering, which was never guaranteed by Rollup as `this.load` could be called by any plugin at any time) and this should only be _additive_, in that it increases the number of files that are type-checked / generated declarations for.
    - So personally, I don't think this needs a minor bump. If it does get a minor bump, we should release a patch before merging this as I've had a bunch of other fixes in the past month or two that have not yet been released.

1. Related to that, I specifically _did not_ touch the "missed" type-checking / declaration generation that uses `parsedConfig.fileNames` to partly workaround this issue (i.e. #345 and the respective declaration generation block)
    - Removing those would almost certainly be considered breaking, since it could remove some files from type-checking / declaration generation. See also the "Note" in #345
    - While #211 says rpt2 shouldn't process those, I don't necessarily agree with that statement, because `tsc` will process those. Not processing `parsedConfig.fileNames` would mean only processing the Rollup `input`, acting _as if_ the `tsconfig` had `files` with only that single file from the Rollup `input` in it. That behavior could make sense to some, but not others, so I'm not sure that that's ideal.
    The "Note" in #345 mentions how users may use `include` globs or `files` arrays to list _other_ files they want type-checking and declarations. These files may not be considered part of the Rollup "bundle" however, so I could see an argument for either direction.
    - In any case, this has not been changed for now. If warranted, we could remove this in a _separate_ PR, and _that one_ would be breaking, but I would not say that _this_ PR in its current state is breaking.
  
## References

Will add some more downstream issues in a list here ([TBD])