### PR TITLE
revert: back to using `vue.d.ts` instead of `.d.ts` for Vue declarations

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -345,7 +345,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 				let fileName = entry.name;
 				if (fileName.includes("?")) // HACK for rollup-plugin-vue, it creates virtual modules in form 'file.vue?rollup-plugin-vue=script.ts'
-					fileName = fileName.split(".vue?", 1) + extension;
+					fileName = fileName.split("?", 1) + extension;
 
 				// If 'useTsconfigDeclarationDir' is in plugin options, directly write to 'declarationDir'.
 				// This may not be under Rollup's output directory, and thus can't be emitted as an asset.


### PR DESCRIPTION
This reverts commit e145d0baebbbef1eec691b99d1ce0dce1e49f38c / PR #336
**NOTE**: this may be considered breaking, so we may want to release this in a breaking release as such. I've left this PR as draft as such. That being said, this could also be considered as just a bugfix as the original PR was made in error and caused a bug.

## Summary

Revert back to using `.vue.d.ts` for Vue declarations

## Details

- Per follow-up discussion on [the original issue](https://github.com/ezolenko/rollup-plugin-typescript2/issues/224#issuecomment-1193350666) and [to-be-reverted PR](https://github.com/ezolenko/rollup-plugin-typescript2/pull/336#issuecomment-1179476746), it seems that the request to use `.d.ts` instead of `.vue.d.ts` was made in error
  - `.d.ts` seems to only be necessary if Vue users were importing `.vue` SFCs without extensions ("extensionless")
    - i.e. `import MyComponent from "./MyComponent"` instead of `import MyComponent from "./MyComponent.vue"`
  - and "extensionless" imports are no longer supported by the Vue team (but used to be)
  - requiring extensionless imports also breaks imports when extensions _are_ used
  - so these are not necessarily compatible with each other, but the Vue team support strongly suggests that `.vue.d.ts` would be the proper way forward

## Credits

Thanks to @andrew0 for finding this problem and providing evidence 🙂 