### PR TITLE
fix(dx): remove extra quote in `emitDeclarationOnly` log statement

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -253,7 +253,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			// note that result.code is non-existent if emitDeclarationOnly per https://github.com/ezolenko/rollup-plugin-typescript2/issues/268
 			if (parsedConfig.options.emitDeclarationOnly)
 			{
-				context.debug(() => `${blue("emitDeclarationOnly")} enabled, not transforming TS'`);
+				context.debug(() => `${blue("emitDeclarationOnly")} enabled, not transforming TS`);
 				return undefined;
 			}
 


### PR DESCRIPTION
## Summary

Just removes an unnecessary quote
- noticed it in #411's logging
- follow-up to #366

## Details

- must've been a copy+paste mistake or something