### PR TITLE
clean: remove `ConsoleContext` entirely by using `buildStart`

### DIFF
--- a/__tests__/context.spec.ts
+++ b/__tests__/context.spec.ts
@@ -1,57 +1,13 @@
 import { jest, test, expect } from "@jest/globals";
 
 import { makeContext } from "./fixtures/context";
-import { ConsoleContext, RollupContext } from "../src/context";
+import { RollupContext } from "../src/context";
 
 (global as any).console = {
 	warn: jest.fn(),
 	log: jest.fn(),
 	info: jest.fn(),
 };
-
-test("ConsoleContext", () => {
-	const proxy = new ConsoleContext(6, "=>");
-
-	proxy.warn("test");
-	expect(console.log).toHaveBeenLastCalledWith("=>test");
-
-	proxy.error("test2");
-	expect(console.log).toHaveBeenLastCalledWith("=>test2");
-
-	proxy.info("test3");
-	expect(console.log).toHaveBeenLastCalledWith("=>test3");
-
-	proxy.debug("test4");
-	expect(console.log).toHaveBeenLastCalledWith("=>test4");
-
-	proxy.warn(() => "ftest");
-	expect(console.log).toHaveBeenLastCalledWith("=>ftest");
-
-	proxy.error(() => "ftest2");
-	expect(console.log).toHaveBeenLastCalledWith("=>ftest2");
-
-	proxy.info(() => "ftest3");
-	expect(console.log).toHaveBeenLastCalledWith("=>ftest3");
-
-	proxy.debug(() => "ftest4");
-	expect(console.log).toHaveBeenLastCalledWith("=>ftest4");
-});
-
-test("ConsoleContext 0 verbosity", () => {
-	const proxy = new ConsoleContext(-100);
-
-	proxy.warn("no-test");
-	expect(console.log).not.toHaveBeenLastCalledWith("no-test");
-
-	proxy.info("no-test2");
-	expect(console.log).not.toHaveBeenLastCalledWith("no-test2");
-
-	proxy.debug("no-test3");
-	expect(console.log).not.toHaveBeenLastCalledWith("no-test3");
-
-	proxy.error("no-test4");
-	expect(console.log).not.toHaveBeenLastCalledWith("no-test4");
-});
 
 test("RollupContext", () => {
 	const innerContext = makeContext();

--- a/__tests__/fixtures/context.ts
+++ b/__tests__/fixtures/context.ts
@@ -1,7 +1,7 @@
 import { jest } from "@jest/globals";
 import { PluginContext } from "rollup";
 
-import { IContext } from "../../src/context";
+import { RollupContext } from "../../src/context";
 
 // if given a function, make sure to call it (for code coverage etc)
 function returnText (message: string | (() => string)) {
@@ -11,11 +11,11 @@ function returnText (message: string | (() => string)) {
 	return message();
 }
 
-export function makeContext(): PluginContext & IContext {
+export function makeContext(): PluginContext & RollupContext {
 	return {
 		error: jest.fn(returnText),
 		warn: jest.fn(returnText),
 		info: jest.fn(returnText),
 		debug: jest.fn(returnText),
-	} as unknown as PluginContext & IContext;
+	} as unknown as PluginContext & RollupContext;
 };

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,13 +1,5 @@
 import { PluginContext } from "rollup";
 
-export interface IContext
-{
-	warn(message: string | (() => string)): void;
-	error(message: string | (() => string)): void;
-	info(message: string | (() => string)): void;
-	debug(message: string | (() => string)): void;
-}
-
 export enum VerbosityLevel
 {
 	Error = 0,
@@ -20,46 +12,8 @@ function getText (message: string | (() => string)): string {
 	return typeof message === "string" ? message : message();
 }
 
-/* tslint:disable:max-classes-per-file -- generally a good rule to follow, but these two classes could basically be one */
-
-/** mainly to be used in options hook, but can be used in other hooks too */
-export class ConsoleContext implements IContext
-{
-	constructor(private verbosity: VerbosityLevel, private prefix: string = "")
-	{
-	}
-
-	public warn(message: string | (() => string)): void
-	{
-		if (this.verbosity < VerbosityLevel.Warning)
-			return;
-		console.log(`${this.prefix}${getText(message)}`);
-	}
-
-	public error(message: string | (() => string)): void
-	{
-		if (this.verbosity < VerbosityLevel.Error)
-			return;
-		console.log(`${this.prefix}${getText(message)}`);
-	}
-
-	public info(message: string | (() => string)): void
-	{
-		if (this.verbosity < VerbosityLevel.Info)
-			return;
-		console.log(`${this.prefix}${getText(message)}`);
-	}
-
-	public debug(message: string | (() => string)): void
-	{
-		if (this.verbosity < VerbosityLevel.Debug)
-			return;
-		console.log(`${this.prefix}${getText(message)}`);
-	}
-}
-
 /** cannot be used in options hook (which does not have this.warn and this.error), but can be in other hooks */
-export class RollupContext implements IContext
+export class RollupContext
 {
 	constructor(private verbosity: VerbosityLevel, private bail: boolean, private context: PluginContext, private prefix: string = "")
 	{
@@ -72,7 +26,7 @@ export class RollupContext implements IContext
 		this.context.warn(`${getText(message)}`);
 	}
 
-	public error(message: string | (() => string)): void
+	public error(message: string | (() => string)): void | never
 	{
 		if (this.verbosity < VerbosityLevel.Error)
 			return;

--- a/src/get-options-overrides.ts
+++ b/src/get-options-overrides.ts
@@ -4,7 +4,7 @@ import { createFilter as createRollupFilter, normalizePath as normalize } from "
 
 import { tsModule } from "./tsproxy";
 import { IOptions } from "./ioptions";
-import { IContext } from "./context";
+import { RollupContext } from "./context";
 
 export function getOptionsOverrides({ useTsconfigDeclarationDir, cacheRoot }: IOptions, preParsedTsconfig?: tsTypes.ParsedCommandLine): tsTypes.CompilerOptions
 {
@@ -51,7 +51,7 @@ function expandIncludeWithDirs(include: string | string[], dirs: string[])
 	return newDirs;
 }
 
-export function createFilter(context: IContext, pluginOptions: IOptions, parsedConfig: tsTypes.ParsedCommandLine)
+export function createFilter(context: RollupContext, pluginOptions: IOptions, parsedConfig: tsTypes.ParsedCommandLine)
 {
 	let included = pluginOptions.include;
 	let excluded = pluginOptions.exclude;

--- a/src/parse-tsconfig.ts
+++ b/src/parse-tsconfig.ts
@@ -2,19 +2,19 @@ import { dirname } from "path";
 import * as _ from "lodash";
 
 import { tsModule } from "./tsproxy";
-import { IContext } from "./context";
+import { RollupContext } from "./context";
 import { printDiagnostics } from "./print-diagnostics";
 import { convertDiagnostic } from "./tscache";
 import { getOptionsOverrides } from "./get-options-overrides";
 import { IOptions } from "./ioptions";
 
-export function parseTsConfig(context: IContext, pluginOptions: IOptions)
+export function parseTsConfig(context: RollupContext, pluginOptions: IOptions)
 {
 	const fileName = tsModule.findConfigFile(pluginOptions.cwd, tsModule.sys.fileExists, pluginOptions.tsconfig);
 
 	// if the value was provided, but no file, fail hard
 	if (pluginOptions.tsconfig !== undefined && !fileName)
-		throw new Error(`rpt2: failed to open '${pluginOptions.tsconfig}'`);
+		context.error(`failed to open '${pluginOptions.tsconfig}'`);
 
 	let loadedConfig: any = {};
 	let baseDir = pluginOptions.cwd;
@@ -29,7 +29,7 @@ export function parseTsConfig(context: IContext, pluginOptions: IOptions)
 		if (result.error !== undefined)
 		{
 			printDiagnostics(context, convertDiagnostic("config", [result.error]), pretty);
-			throw new Error(`rpt2: failed to parse '${fileName}'`);
+			context.error(`failed to parse '${fileName}'`);
 		}
 
 		loadedConfig = result.config;
@@ -46,7 +46,7 @@ export function parseTsConfig(context: IContext, pluginOptions: IOptions)
 
 	const module = parsedTsConfig.options.module!;
 	if (module !== tsModule.ModuleKind.ES2015 && module !== tsModule.ModuleKind.ES2020 && module !== tsModule.ModuleKind.ESNext)
-		throw new Error(`rpt2: Incompatible tsconfig option. Module resolves to '${tsModule.ModuleKind[module]}'. This is incompatible with Rollup, please use 'module: "ES2015"', 'module: "ES2020"', or 'module: "ESNext"'.`);
+		context.error(`Incompatible tsconfig option. Module resolves to '${tsModule.ModuleKind[module]}'. This is incompatible with Rollup, please use 'module: "ES2015"', 'module: "ES2020"', or 'module: "ESNext"'.`);
 
 	printDiagnostics(context, convertDiagnostic("config", parsedTsConfig.errors), pretty);
 

--- a/src/print-diagnostics.ts
+++ b/src/print-diagnostics.ts
@@ -1,10 +1,10 @@
 import { red, white, yellow } from "colors/safe";
 
 import { tsModule } from "./tsproxy";
-import { IContext } from "./context";
+import { RollupContext } from "./context";
 import { IDiagnostics } from "./tscache";
 
-export function printDiagnostics(context: IContext, diagnostics: IDiagnostics[], pretty = true): void
+export function printDiagnostics(context: RollupContext, diagnostics: IDiagnostics[], pretty = true): void
 {
 	diagnostics.forEach((diagnostic) =>
 	{

--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -5,7 +5,7 @@ import { Graph, alg } from "graphlib";
 import objHash from "object-hash";
 import { blue, yellow, green } from "colors/safe";
 
-import { IContext } from "./context";
+import { RollupContext } from "./context";
 import { RollingCache } from "./rollingcache";
 import { ICache } from "./icache";
 import { tsModule } from "./tsproxy";
@@ -111,7 +111,7 @@ export class TsCache
 	private syntacticDiagnosticsCache!: ICache<IDiagnostics[]>;
 	private hashOptions = { algorithm: "sha1", ignoreUnknown: false };
 
-	constructor(private noCache: boolean, hashIgnoreUnknown: boolean, private host: tsTypes.LanguageServiceHost, private cacheRoot: string, private options: tsTypes.CompilerOptions, private rollupConfig: any, rootFilenames: string[], private context: IContext)
+	constructor(private noCache: boolean, hashIgnoreUnknown: boolean, private host: tsTypes.LanguageServiceHost, private cacheRoot: string, private options: tsTypes.CompilerOptions, private rollupConfig: any, rootFilenames: string[], private context: RollupContext)
 	{
 		this.dependencyTree = new Graph({ directed: true });
 		this.dependencyTree.setDefaultNodeLabel((_node: string) => ({ dirty: false }));


### PR DESCRIPTION
## Summary

Remove `ConsoleContext` (and the need for it) by using the [`buildStart`](https://rollupjs.org/guide/en/#buildstart) hook instead of the [`options`](https://rollupjs.org/guide/en/#options) hook
- Follow-up to https://github.com/ezolenko/rollup-plugin-typescript2/pull/345#issuecomment-1200277838

## Details

- the only reason that `ConsoleContext` was still used was because the `options` hook doesn't support certain context functions like `this.error` / `this.warn` etc
  - but `buildStart` does! so we can just move pretty much everything into `buildStart` instead
    - didn't move setting `rollupOptions` because that value gets hashed and the value in `buildStart` is different, as it is after all plugins' `options` hooks have ran
      - I'm not sure which is the better one to hash, but I left it as is so that the hash remains the same
    - this way we don't need `ConsoleContext` what-so-ever and so can remove it entirely!
      - as well as `IContext`, its tests, etc

- use `this.error` instead of `throw`ing errors in `parse-tsconfig` as it exists now
  - couldn't in the `options` hook, can in `buildStart`
  - this also ensure we don't have all the `rpt2: ` prefixes ever missing again
    - c.f. ff8895103c8466694e7d8eeb734f51d2850670d8, #382
  - refactor `parse-tsconfig.spec` to account for this change
