### PR TITLE
docs: add a simple `CHANGELOG.md` that references GH releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+# Changelog
+
+See release notes on [the GitHub Releases page](https://github.com/ezolenko/rollup-plugin-typescript2/releases).


### PR DESCRIPTION
## Summary

Add a `CHANGELOG.md` that references the release notes on [GH Releases](https://github.com/ezolenko/rollup-plugin-typescript2/releases)
- Resolves #418

## Details

- we have release notes already in GH releases, so add a simple `CHANGELOG.md` that references it
  - I use something [similar](https://github.com/agilgur5/react-signature-canvas/blob/64c7c4989cb6dceb8ac92e03d43070b8ff5d1043/CHANGELOG.md) in most of my libraries

- this should hopefully make it easier for users to find the release notes in case they hadn't seen them on GH before

