### PR TITLE
fix: don't error out while catching a `buildStart` error

### DIFF
--- a/__tests__/integration/errors.spec.ts
+++ b/__tests__/integration/errors.spec.ts
@@ -88,3 +88,10 @@ test("integration - type-only import error - abortOnError: false / check: false"
   expect(output.length).toEqual(files.length); // no other files
   expect(onwarn).toBeCalledTimes(1);
 });
+
+// integration test variant of parse-tsconfig unit test, to test how other hooks interact with an error thrown in buildStart
+test("integration - tsconfig error", async () => {
+  await expect(genBundle("semantic.ts", {
+    tsconfigOverride: { compilerOptions: { module: "none" } },
+  })).rejects.toThrow("Incompatible tsconfig option. Module resolves to 'None'. This is incompatible with Rollup, please use");
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 		if (!watchMode && !noErrors)
 			context.info(yellow("there were errors or warnings."));
 
-		cache.done();
+		cache?.done(); // if there's an initialization error in `buildStart`, such as a `tsconfig` error, the cache may not exist yet
 	}
 
 	const pluginOptions: IOptions = Object.assign({},


### PR DESCRIPTION
## Summary

If an error occurs during the `buildStart` hook, make sure that the `buildEnd` hook doesn't hide the error with its own error
- in this case the `buildDone` func had an uninitialized `cache` var, as it's initialized _in `buildStart` after_ this thrown error
- Fixes #421 
  - See root cause analysis in https://github.com/ezolenko/rollup-plugin-typescript2/issues/421#issuecomment-1247116271
    - Caused by #414 + #415

## Details

- per in-line comment, if an error occurs during `buildStart` initialization, then the `cache` may not exist yet during `buildDone`
  - since we now use `context.error` instead of `throw` during initialization (from the `options` -> `buildStart` change), `buildEnd` will run during initialization - and the `cache` var is initialized in `buildStart` as well, so if an error occurs before then, the `cache` won't exist - we should gracefully handle this in all cases, since it's possible that even creating the `cache` could throw an error

- this error was hiding the underlying error, which was problematic for DX as well as bug reports (see my [issue follow-up](https://github.com/ezolenko/rollup-plugin-typescript2/issues/421#issuecomment-1246797662))

- add an integration test for `tsconfig` to make sure this code works
  - while this is similar to the previous `tsconfig` integration tests (that were moved to unit tests), this covers all cases of `buildStart` errors, and is not specific to the different `tsconfig` errors (unlike the unit tests)
  - this test will fail without the source code changes in this commit

## Misc Notes

Would be good for a patch release! Especially as this error currently hides actual errors 😕 