### PR TITLE
clean(deps): remove unused `@types/resolve`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,6 @@
         "@types/lodash": "4.14.161",
         "@types/node": "8.0.47",
         "@types/object-hash": "1.3.3",
-        "@types/resolve": "1.17.1",
         "@types/semver": "7.1.0",
         "colors": "1.4.0",
         "graphlib": "2.1.8",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "@types/lodash": "4.14.161",
     "@types/node": "8.0.47",
     "@types/object-hash": "1.3.3",
-    "@types/resolve": "1.17.1",
     "@types/semver": "7.1.0",
     "colors": "1.4.0",
     "graphlib": "2.1.8",


### PR DESCRIPTION
## Summary

Remove `@types/resolve` from devDeps
- Follow-up to #367

## Details

- `resolve` was removed in #367, so typings for it are no longer necessary either