### PR TITLE
test: increase `no-errors` integration timeout to 20s

### DIFF
--- a/__tests__/integration/no-errors.spec.ts
+++ b/__tests__/integration/no-errors.spec.ts
@@ -7,8 +7,8 @@ import { RPT2Options } from "../../src/index";
 import { filesArr } from "./fixtures/no-errors";
 import { findName, genBundle as genBundleH } from "./helpers";
 
-// increase timeout to 15s for whole file since CI occassionally timed out -- these are integration and cache tests, so longer timeout is warranted
-jest.setTimeout(15000);
+// increase timeout to 20s for whole file since CI occassionally timed out -- these are integration and cache tests, so longer timeout is warranted
+jest.setTimeout(20000);
 
 const local = (x: string) => path.resolve(__dirname, x);
 const testDir = local("__temp/no-errors");


### PR DESCRIPTION
## Summary

Increase the timeout on the `no-errors` integration test suite
- Follow-up to #371, where, per the commits, I bumped it several times due to CI timeouts

## Details

- this was still occasionally failing on CI at 15s, so bump up a bit
  - c.f. [this run](https://github.com/ezolenko/rollup-plugin-typescript2/actions/runs/3075482590/jobs/4968935300), [this run](https://github.com/ezolenko/rollup-plugin-typescript2/actions/runs/3038898669/jobs/4893183507), [this run](https://github.com/ezolenko/rollup-plugin-typescript2/actions/runs/3038898669/jobs/4893561438), and many more
  - only `no-errors` was timing out, which makes sense, since it does 3 builds for the first test to test against the cache
    - this potentially could be optimized, but it started getting complicated to do so (including some concurrency issues) - so punting on that for now and just increasing the timeout
    
Note that these have never timed out on me locally, only in CI 🤷 