### PR TITLE
support typescript 5

### DIFF
--- a/__tests__/get-options-overrides.spec.ts
+++ b/__tests__/get-options-overrides.spec.ts
@@ -23,7 +23,7 @@ const forcedOptions: ts.CompilerOptions = {
 	importHelpers: true,
 	inlineSourceMap: false,
 	// typescript 5 renamed NodeJs to Node10, but we still need to support older versions
-	moduleResolution: ts.ModuleResolutionKind.NodeJs ?? (ts.ModuleResolutionKind as any).Node10,	
+	moduleResolution: ts.ModuleResolutionKind.NodeJs ?? (ts.ModuleResolutionKind as any).Node10,
 	noEmit: false,
 	noEmitOnError: false,
 	noEmitHelpers: false,

--- a/__tests__/get-options-overrides.spec.ts
+++ b/__tests__/get-options-overrides.spec.ts
@@ -6,10 +6,7 @@ import { remove } from "fs-extra";
 
 import { makeOptions } from "./fixtures/options";
 import { makeContext } from "./fixtures/context";
-import {
-	getOptionsOverrides,
-	createFilter,
-} from "../src/get-options-overrides";
+import { getOptionsOverrides, createFilter } from "../src/get-options-overrides";
 
 const local = (x: string) => normalize(path.resolve(__dirname, x));
 const cacheDir = local("__temp/get-options-overrides");
@@ -25,10 +22,8 @@ const forcedOptions: ts.CompilerOptions = {
 	allowNonTsExtensions: true,
 	importHelpers: true,
 	inlineSourceMap: false,
-	moduleResolution:
-		// typescript 5 renamed NodeJs to Node10, but we still need to support older versions
-		ts.ModuleResolutionKind.NodeJs ??
-		(ts.ModuleResolutionKind as any).Node10,
+	// typescript 5 renamed NodeJs to Node10, but we still need to support older versions
+	moduleResolution: ts.ModuleResolutionKind.NodeJs ?? (ts.ModuleResolutionKind as any).Node10,	
 	noEmit: false,
 	noEmitOnError: false,
 	noEmitHelpers: false,
@@ -127,7 +122,7 @@ test("createFilter - rootDirs", () => {
 	const preParsedTsConfig = {
 		...defaultPreParsedTsConfig,
 		options: {
-			rootDirs: ["src", "lib"],
+			rootDirs: ["src", "lib"]
 		},
 	};
 	const filter = createFilter(makeContext(), config, preParsedTsConfig);
@@ -148,7 +143,10 @@ test("createFilter - projectReferences", () => {
 	const config = { ...defaultConfig, include: "*.ts+(|x)" };
 	const preParsedTsConfig = {
 		...defaultPreParsedTsConfig,
-		projectReferences: [{ path: "src" }, { path: "lib" }],
+		projectReferences: [
+			{ path: "src" },
+			{ path: "lib" },
+		],
 	};
 	const filter = createFilter(makeContext(), config, preParsedTsConfig);
 

--- a/__tests__/get-options-overrides.spec.ts
+++ b/__tests__/get-options-overrides.spec.ts
@@ -6,7 +6,10 @@ import { remove } from "fs-extra";
 
 import { makeOptions } from "./fixtures/options";
 import { makeContext } from "./fixtures/context";
-import { getOptionsOverrides, createFilter } from "../src/get-options-overrides";
+import {
+	getOptionsOverrides,
+	createFilter,
+} from "../src/get-options-overrides";
 
 const local = (x: string) => normalize(path.resolve(__dirname, x));
 const cacheDir = local("__temp/get-options-overrides");
@@ -22,7 +25,10 @@ const forcedOptions: ts.CompilerOptions = {
 	allowNonTsExtensions: true,
 	importHelpers: true,
 	inlineSourceMap: false,
-	moduleResolution: ts.ModuleResolutionKind.NodeJs,
+	moduleResolution:
+		// typescript 5 renamed NodeJs to Node10, but we still need to support older versions
+		ts.ModuleResolutionKind.NodeJs ??
+		(ts.ModuleResolutionKind as any).Node10,
 	noEmit: false,
 	noEmitOnError: false,
 	noEmitHelpers: false,
@@ -121,7 +127,7 @@ test("createFilter - rootDirs", () => {
 	const preParsedTsConfig = {
 		...defaultPreParsedTsConfig,
 		options: {
-			rootDirs: ["src", "lib"]
+			rootDirs: ["src", "lib"],
 		},
 	};
 	const filter = createFilter(makeContext(), config, preParsedTsConfig);
@@ -142,10 +148,7 @@ test("createFilter - projectReferences", () => {
 	const config = { ...defaultConfig, include: "*.ts+(|x)" };
 	const preParsedTsConfig = {
 		...defaultPreParsedTsConfig,
-		projectReferences: [
-			{ path: "src" },
-			{ path: "lib" },
-		],
+		projectReferences: [{ path: "src" }, { path: "lib" }],
 	};
 	const filter = createFilter(makeContext(), config, preParsedTsConfig);
 

--- a/src/get-options-overrides.ts
+++ b/src/get-options-overrides.ts
@@ -1,18 +1,13 @@
 import * as path from "path";
 import * as tsTypes from "typescript";
-import {
-	createFilter as createRollupFilter,
-	normalizePath as normalize,
-} from "@rollup/pluginutils";
+import { createFilter as createRollupFilter, normalizePath as normalize } from "@rollup/pluginutils";
 
 import { tsModule } from "./tsproxy";
 import { IOptions } from "./ioptions";
 import { RollupContext } from "./context";
 
-export function getOptionsOverrides(
-	{ useTsconfigDeclarationDir, cacheRoot }: IOptions,
-	preParsedTsconfig?: tsTypes.ParsedCommandLine
-): tsTypes.CompilerOptions {
+export function getOptionsOverrides({ useTsconfigDeclarationDir, cacheRoot }: IOptions, preParsedTsconfig?: tsTypes.ParsedCommandLine): tsTypes.CompilerOptions
+{
 	const overrides: tsTypes.CompilerOptions = {
 		noEmitHelpers: false,
 		importHelpers: true,
@@ -22,71 +17,59 @@ export function getOptionsOverrides(
 		inlineSourceMap: false,
 		outDir: normalize(`${cacheRoot}/placeholder`), // need an outdir that is different from source or tsconfig parsing trips up. https://github.com/Microsoft/TypeScript/issues/24715
 		// typescript 5 renamed NodeJs to Node10, but we still need to support older versions
-		moduleResolution:
-			tsModule.ModuleResolutionKind.NodeJs ??
-			(tsModule.ModuleResolutionKind as any).Node10,
+		moduleResolution: tsModule.ModuleResolutionKind.NodeJs ?? (tsModule.ModuleResolutionKind as any).Node10,
 		allowNonTsExtensions: true,
 	};
 
-	if (!preParsedTsconfig) return overrides;
+	if (!preParsedTsconfig)
+		return overrides;
 
 	if (preParsedTsconfig.options.module === undefined)
 		overrides.module = tsModule.ModuleKind.ES2015;
 
 	// only set declarationDir if useTsconfigDeclarationDir is enabled
-	if (!useTsconfigDeclarationDir) overrides.declarationDir = undefined;
+	if (!useTsconfigDeclarationDir)
+		overrides.declarationDir = undefined;
 
 	// unsetting sourceRoot if sourceMap is not enabled (in case original tsconfig had inlineSourceMap set that is being unset and would cause TS5051)
 	const sourceMap = preParsedTsconfig.options.sourceMap;
-	if (!sourceMap) overrides.sourceRoot = undefined;
+	if (!sourceMap)
+		overrides.sourceRoot = undefined;
 
 	return overrides;
 }
 
-function expandIncludeWithDirs(include: string | string[], dirs: string[]) {
+function expandIncludeWithDirs(include: string | string[], dirs: string[])
+{
 	const newDirs: string[] = [];
 
-	dirs.forEach((root) => {
+	dirs.forEach(root => {
 		if (include instanceof Array)
-			include.forEach((x) => newDirs.push(normalize(path.join(root, x))));
-		else newDirs.push(normalize(path.join(root, include)));
+			include.forEach(x => newDirs.push(normalize(path.join(root, x))));
+		else
+			newDirs.push(normalize(path.join(root, include)));
 	});
 	return newDirs;
 }
 
-export function createFilter(
-	context: RollupContext,
-	pluginOptions: IOptions,
-	parsedConfig: tsTypes.ParsedCommandLine
-) {
+export function createFilter(context: RollupContext, pluginOptions: IOptions, parsedConfig: tsTypes.ParsedCommandLine)
+{
 	let included = pluginOptions.include;
 	let excluded = pluginOptions.exclude;
 
-	if (parsedConfig.options.rootDirs) {
-		included = expandIncludeWithDirs(
-			included,
-			parsedConfig.options.rootDirs
-		);
-		excluded = expandIncludeWithDirs(
-			excluded,
-			parsedConfig.options.rootDirs
-		);
+	if (parsedConfig.options.rootDirs)
+	{
+		included = expandIncludeWithDirs(included, parsedConfig.options.rootDirs);
+		excluded = expandIncludeWithDirs(excluded, parsedConfig.options.rootDirs);
 	}
 
-	if (parsedConfig.projectReferences) {
-		included = expandIncludeWithDirs(
-			included,
-			parsedConfig.projectReferences.map((x) => x.path)
-		).concat(included);
-		excluded = expandIncludeWithDirs(
-			excluded,
-			parsedConfig.projectReferences.map((x) => x.path)
-		).concat(excluded);
+	if (parsedConfig.projectReferences)
+	{
+		included = expandIncludeWithDirs(included, parsedConfig.projectReferences.map((x) => x.path)).concat(included);
+		excluded = expandIncludeWithDirs(excluded, parsedConfig.projectReferences.map((x) => x.path)).concat(excluded);
 	}
 
 	context.debug(() => `included:\n${JSON.stringify(included, undefined, 4)}`);
 	context.debug(() => `excluded:\n${JSON.stringify(excluded, undefined, 4)}`);
-	return createRollupFilter(included, excluded, {
-		resolve: parsedConfig.options.rootDir,
-	});
+	return createRollupFilter(included, excluded, { resolve: parsedConfig.options.rootDir });
 }

--- a/src/get-options-overrides.ts
+++ b/src/get-options-overrides.ts
@@ -1,13 +1,18 @@
 import * as path from "path";
 import * as tsTypes from "typescript";
-import { createFilter as createRollupFilter, normalizePath as normalize } from "@rollup/pluginutils";
+import {
+	createFilter as createRollupFilter,
+	normalizePath as normalize,
+} from "@rollup/pluginutils";
 
 import { tsModule } from "./tsproxy";
 import { IOptions } from "./ioptions";
 import { RollupContext } from "./context";
 
-export function getOptionsOverrides({ useTsconfigDeclarationDir, cacheRoot }: IOptions, preParsedTsconfig?: tsTypes.ParsedCommandLine): tsTypes.CompilerOptions
-{
+export function getOptionsOverrides(
+	{ useTsconfigDeclarationDir, cacheRoot }: IOptions,
+	preParsedTsconfig?: tsTypes.ParsedCommandLine
+): tsTypes.CompilerOptions {
 	const overrides: tsTypes.CompilerOptions = {
 		noEmitHelpers: false,
 		importHelpers: true,
@@ -16,59 +21,72 @@ export function getOptionsOverrides({ useTsconfigDeclarationDir, cacheRoot }: IO
 		noEmitOnError: false,
 		inlineSourceMap: false,
 		outDir: normalize(`${cacheRoot}/placeholder`), // need an outdir that is different from source or tsconfig parsing trips up. https://github.com/Microsoft/TypeScript/issues/24715
-		moduleResolution: tsModule.ModuleResolutionKind.NodeJs,
+		// typescript 5 renamed NodeJs to Node10, but we still need to support older versions
+		moduleResolution:
+			tsModule.ModuleResolutionKind.NodeJs ??
+			(tsModule.ModuleResolutionKind as any).Node10,
 		allowNonTsExtensions: true,
 	};
 
-	if (!preParsedTsconfig)
-		return overrides;
+	if (!preParsedTsconfig) return overrides;
 
 	if (preParsedTsconfig.options.module === undefined)
 		overrides.module = tsModule.ModuleKind.ES2015;
 
 	// only set declarationDir if useTsconfigDeclarationDir is enabled
-	if (!useTsconfigDeclarationDir)
-		overrides.declarationDir = undefined;
+	if (!useTsconfigDeclarationDir) overrides.declarationDir = undefined;
 
 	// unsetting sourceRoot if sourceMap is not enabled (in case original tsconfig had inlineSourceMap set that is being unset and would cause TS5051)
 	const sourceMap = preParsedTsconfig.options.sourceMap;
-	if (!sourceMap)
-		overrides.sourceRoot = undefined;
+	if (!sourceMap) overrides.sourceRoot = undefined;
 
 	return overrides;
 }
 
-function expandIncludeWithDirs(include: string | string[], dirs: string[])
-{
+function expandIncludeWithDirs(include: string | string[], dirs: string[]) {
 	const newDirs: string[] = [];
 
-	dirs.forEach(root => {
+	dirs.forEach((root) => {
 		if (include instanceof Array)
-			include.forEach(x => newDirs.push(normalize(path.join(root, x))));
-		else
-			newDirs.push(normalize(path.join(root, include)));
+			include.forEach((x) => newDirs.push(normalize(path.join(root, x))));
+		else newDirs.push(normalize(path.join(root, include)));
 	});
 	return newDirs;
 }
 
-export function createFilter(context: RollupContext, pluginOptions: IOptions, parsedConfig: tsTypes.ParsedCommandLine)
-{
+export function createFilter(
+	context: RollupContext,
+	pluginOptions: IOptions,
+	parsedConfig: tsTypes.ParsedCommandLine
+) {
 	let included = pluginOptions.include;
 	let excluded = pluginOptions.exclude;
 
-	if (parsedConfig.options.rootDirs)
-	{
-		included = expandIncludeWithDirs(included, parsedConfig.options.rootDirs);
-		excluded = expandIncludeWithDirs(excluded, parsedConfig.options.rootDirs);
+	if (parsedConfig.options.rootDirs) {
+		included = expandIncludeWithDirs(
+			included,
+			parsedConfig.options.rootDirs
+		);
+		excluded = expandIncludeWithDirs(
+			excluded,
+			parsedConfig.options.rootDirs
+		);
 	}
 
-	if (parsedConfig.projectReferences)
-	{
-		included = expandIncludeWithDirs(included, parsedConfig.projectReferences.map((x) => x.path)).concat(included);
-		excluded = expandIncludeWithDirs(excluded, parsedConfig.projectReferences.map((x) => x.path)).concat(excluded);
+	if (parsedConfig.projectReferences) {
+		included = expandIncludeWithDirs(
+			included,
+			parsedConfig.projectReferences.map((x) => x.path)
+		).concat(included);
+		excluded = expandIncludeWithDirs(
+			excluded,
+			parsedConfig.projectReferences.map((x) => x.path)
+		).concat(excluded);
 	}
 
 	context.debug(() => `included:\n${JSON.stringify(included, undefined, 4)}`);
 	context.debug(() => `excluded:\n${JSON.stringify(excluded, undefined, 4)}`);
-	return createRollupFilter(included, excluded, { resolve: parsedConfig.options.rootDir });
+	return createRollupFilter(included, excluded, {
+		resolve: parsedConfig.options.rootDir,
+	});
 }


### PR DESCRIPTION
## Summary

Add support for TS5.0 by using ModuleResolutionKind.Node10 if ModuleResolutionKind.NodeJs is not found
Fixes #436 

## Details

TS5 renamed ModuleResolutionKind.NodeJs to Node10, so the first one returns undefined, which actually means Classic module resolution

I had to use as any for it to compile. If this project ever uses TS5 as devDependency then the as any will probably need to be reversed.