### PR TITLE
disabling cache in watch mode

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,10 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			service = tsModule.createLanguageService(servicesHost, documentRegistry);
 			servicesHost.setLanguageService(service);
 
-			cache = new TsCache(pluginOptions.clean, pluginOptions.objectHashIgnoreUnknownHack, servicesHost, pluginOptions.cacheRoot, parsedConfig.options, rollupOptions, parsedConfig.fileNames, context);
+			const runClean = pluginOptions.clean;
+			const noCache = pluginOptions.clean || watchMode;
+
+			cache = new TsCache(noCache, runClean, pluginOptions.objectHashIgnoreUnknownHack, servicesHost, pluginOptions.cacheRoot, parsedConfig.options, rollupOptions, parsedConfig.fileNames, context);
 
 			// reset transformedFiles Set on each watch cycle
 			transformedFiles = new Set<string>();

--- a/src/tscache.ts
+++ b/src/tscache.ts
@@ -78,16 +78,16 @@ export class TsCache
 	private syntacticDiagnosticsCache!: ICache<IDiagnostics[]>;
 	private hashOptions = { algorithm: "sha1", ignoreUnknown: false };
 
-	constructor(private noCache: boolean, hashIgnoreUnknown: boolean, private host: tsTypes.LanguageServiceHost, private cacheRoot: string, private options: tsTypes.CompilerOptions, private rollupConfig: any, rootFilenames: string[], private context: RollupContext)
+	constructor(private noCache: boolean, runClean: boolean, hashIgnoreUnknown: boolean, private host: tsTypes.LanguageServiceHost, private cacheRoot: string, private options: tsTypes.CompilerOptions, private rollupConfig: any, rootFilenames: string[], private context: RollupContext)
 	{
 		this.dependencyTree = new Graph({ directed: true });
 		this.dependencyTree.setDefaultNodeLabel((_node: string) => ({ dirty: false }));
 
-		if (noCache)
-		{
+		if (runClean)
 			this.clean();
+
+		if (noCache)
 			return;
-		}
 
 		this.hashOptions.ignoreUnknown = hashIgnoreUnknown;
 		this.cacheDir = `${this.cacheRoot}/${this.cachePrefix}${objHash(


### PR DESCRIPTION
## Summary

Fixes #443, should incidentally fix #444

## Details

Disabling cache in watch mode, speeds it up considerably, which was the whole point of having a cache in the first place.

This is slightly different from simply using `clean: true` for watch mode -- `clean: true` also deletes all old caches. `clean: false` in watch mode would bypass cache without touching old caches.
