### PR TITLE
fix: hardcode declaration extension check

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -277,6 +277,9 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			// Rollup can't see these otherwise, because they are "emit-less" and produce no JS
 			if (result.references && supportsThisLoad) {
 				for (const ref of result.references) {
+					// pre-emptively filter out some files (for efficiency, as well as to workaround a Rollup bug: https://github.com/ezolenko/rollup-plugin-typescript2/issues/426#issuecomment-1264812897)
+					if (ref.endsWith(".d.ts"))
+						continue;
 					if (!filter(ref))
 						continue;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -285,7 +285,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			// Rollup can't see these otherwise, because they are "emit-less" and produce no JS
 			if (result.references && supportsThisLoad) {
 				for (const ref of result.references) {
-					// pre-emptively filter out some files (for efficiency, as well as to workaround a Rollup bug: https://github.com/ezolenko/rollup-plugin-typescript2/issues/426#issuecomment-1264812897)
+					// pre-emptively filter out files that we don't resolve ourselves (e.g. declarations). don't add new files to Rollup's pipeline if we can't resolve them
 					if (!shouldResolve(ref))
 						continue;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 	/** common resolution check -- only resolve files that aren't declarations and pass `filter` */
 	const shouldResolve = (id: string): boolean => {
-		if (id.endsWith(".d.ts"))
+		if (id.endsWith(".d.ts") || id.endsWith(".d.cts") || id.endsWith(".d.mts"))
 			return false;
 
 		if (!filter(id))


### PR DESCRIPTION
## Summary

<!--
  A short, 1-3 sentence summary of what this PR changes.
  Add "Fixes #<issue-num>" if this resolves a particular issue.
-->

Follow-up to https://github.com/ezolenko/rollup-plugin-typescript2/pull/451#discussion_r1256333929, ensure declarations are _always_ ignored during resolution.
- Technically, this fixes a tiny new regression whereby a user could have accidentally (or incorrectly) made rpt2 try to process a directly imported declaration

## Details

<!--
  A **detailed** description of what this PR changes and _why_ it changes that.
-->

- rpt2 should _always_ ignore declarations
  - regardless of the `exclude`; as in, if a user accidentally removes declarations in an override, rpt2 should still not directly read declarations
    - as they are normally read ambiently by TS and not _directly_ by Rollup or TS
    
- this also ensures that the `resolveId` check is the same as the type-only resolve pre-check
  - adds a comment referencing why this is done. see my commit message step-by-step details on that one, it's a bit complicated logic
    
Cherry-pick of [two](https://github.com/agilgur5/rollup-plugin-typescript2/commit/61ef625b85dda9f397fecc0f17dfe482d4927700) [commits](https://github.com/agilgur5/rollup-plugin-typescript2/commit/15bd6ec3bbf448aac7c02d69c3a360a256724fa3) from October that I had on a different, incomplete branch for #426
