### PR TITLE
fix(host): invalidate cache less to speed up compilation for large projects

### DIFF
--- a/src/host.ts
+++ b/src/host.ts
@@ -11,7 +11,7 @@ export class LanguageServiceHost implements tsTypes.LanguageServiceHost
 	private service?: tsTypes.LanguageService;
 	private fileNames: Set<string>;
 
-	constructor(private parsedConfig: tsTypes.ParsedCommandLine, private transformers: TransformerFactoryCreator[], private cwd: string)
+	constructor(private parsedConfig: tsTypes.ParsedCommandLine, private transformers: TransformerFactoryCreator[], private cwd: string, private filter: (id: string | unknown) => boolean)
 	{
 		this.fileNames = new Set(parsedConfig.fileNames);
 	}
@@ -39,6 +39,9 @@ export class LanguageServiceHost implements tsTypes.LanguageServiceHost
 		const snapshot = tsModule.ScriptSnapshot.fromString(source);
 		this.snapshots[fileName] = snapshot;
 		this.versions[fileName] = (this.versions[fileName] || 0) + 1;
+
+		if (this.filter(fileName))
+			this.fileNames.add(fileName);
 
 		return snapshot;
 	}

--- a/src/host.ts
+++ b/src/host.ts
@@ -31,11 +31,10 @@ export class LanguageServiceHost implements tsTypes.LanguageServiceHost
 	{
 		fileName = normalize(fileName);
 
-		const originalSnapshot = this.snapshots[fileName];
-
-		if (originalSnapshot && originalSnapshot.getText(0, originalSnapshot.getLength()) === source) {
-			return originalSnapshot;
-		}
+		// don't update the snapshot if there are no changes
+		const prevSnapshot = this.snapshots[fileName];
+		if (prevSnapshot?.getText(0, prevSnapshot.getLength()) === source)
+			return prevSnapshot;
 
 		const snapshot = tsModule.ScriptSnapshot.fromString(source);
 		this.snapshots[fileName] = snapshot;

--- a/src/host.ts
+++ b/src/host.ts
@@ -31,10 +31,16 @@ export class LanguageServiceHost implements tsTypes.LanguageServiceHost
 	{
 		fileName = normalize(fileName);
 
+		const originalSnapshot = this.snapshots[fileName];
+
+		if (originalSnapshot && originalSnapshot.getText(0, originalSnapshot.getLength()) === source) {
+			return originalSnapshot;
+		}
+
 		const snapshot = tsModule.ScriptSnapshot.fromString(source);
 		this.snapshots[fileName] = snapshot;
 		this.versions[fileName] = (this.versions[fileName] || 0) + 1;
-		this.fileNames.add(fileName);
+
 		return snapshot;
 	}
 
@@ -46,7 +52,7 @@ export class LanguageServiceHost implements tsTypes.LanguageServiceHost
 			return this.snapshots[fileName];
 
 		const source = tsModule.sys.readFile(fileName);
-		if (source)
+		if (source !== undefined)
 			return this.setSnapshot(fileName, source);
 
 		return undefined;

--- a/src/host.ts
+++ b/src/host.ts
@@ -27,14 +27,19 @@ export class LanguageServiceHost implements tsTypes.LanguageServiceHost
 		this.service = service;
 	}
 
-	public setSnapshot(fileName: string, source: string): tsTypes.IScriptSnapshot
+	public setSnapshot(fileName: string, source: string, forcedUpdate = false): tsTypes.IScriptSnapshot
 	{
 		fileName = normalize(fileName);
 
 		// don't update the snapshot if there are no changes
 		const prevSnapshot = this.snapshots[fileName];
-		if (prevSnapshot?.getText(0, prevSnapshot.getLength()) === source)
+		if (prevSnapshot?.getText(0, prevSnapshot.getLength()) === source) {
+			if (forcedUpdate) {
+				this.versions[fileName] = (this.versions[fileName] || 0) + 1;
+			}
+
 			return prevSnapshot;
+		}
 
 		const snapshot = tsModule.ScriptSnapshot.fromString(source);
 		this.snapshots[fileName] = snapshot;

--- a/src/index.ts
+++ b/src/index.ts
@@ -245,7 +245,8 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 			if (!filter(id))
 				return undefined;
 
-			const snapshot = servicesHost.setSnapshot(id, code);
+			// force version update under watch mode to ensure recompile
+			const snapshot = servicesHost.setSnapshot(id, code, watchMode);
 
 			// getting compiled file from cache or from ts
 			const result = cache.getCompiled(id, snapshot, () =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -174,7 +174,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 			filter = createFilter(context, pluginOptions, parsedConfig);
 
-			servicesHost = new LanguageServiceHost(parsedConfig, pluginOptions.transformers, pluginOptions.cwd);
+			servicesHost = new LanguageServiceHost(parsedConfig, pluginOptions.transformers, pluginOptions.cwd, filter);
 			service = tsModule.createLanguageService(servicesHost, documentRegistry);
 			servicesHost.setLanguageService(service);
 


### PR DESCRIPTION
## Summary

Fixes a few problems related to `host.ts` and speed up compilation for large projects.

<!--
  A short, 1-3 sentence summary of what this PR changes.
  Add "Fixes #<issue-num>" if this resolves a particular issue.
-->

## Details

<!--
  A **detailed** description of what this PR changes and _why_ it changes that.
-->

The current version of `rollup-plugin-typescript2` causes the TypeScript cache to get constantly invalidated, for each entry file during a single rollup build, causing build time to increase non-linearly. For for fairly complicated projects, this easily bloat into minutes (about 400s for our project with ~50 files and ~15000 locs).

I've identified and fixed these problems that caused this:

- In `setSnapshot`, file version is increased unnecessarily when source hasn't changed.
- Files in `node_modules` are added incorrectly into LanguageServiceHost.fileNames by `setSnapshot`, since the function is called indirectly for all dependency files discovered while type checking. `fileNames` should be the list of entry files for this build, there's no point updating it during the build process.
- In `getScriptSnapshot`, also create snapshot when file is empty, otherwise it would be marked as 'missing' and invalidate the cache.

I've verified that the updated code can compile itself and our company project, making absolutely no changes to the output. The new compile time is 14s compared to 400s.

You can override `rollup-plugin-typescript2` with `@std4453/rollup-plugin-typescript2` to try it out, which is forked from version `0.36.1`.