### PR TITLE
ci(deps): update LTS Node from 18, 20 to 20, 22

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [20.x, 22.x]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:


### PR DESCRIPTION


## Summary

<!--
  A short, 1-3 sentence summary of what this PR changes.
  Add "Fixes #<issue-num>" if this resolves a particular issue.
-->

Remove EoL Node 18 and add LTS Node 22 to CI matrix

## Details

<!--
  A **detailed** description of what this PR changes and _why_ it changes that.
-->

- per https://nodejs.org/en/about/eol#eol-versions, Node 18 was EoL in March/April 2025
  - so remove it from the CI matrix and add LTS Node 22 instead

## Verification

I'm on Node 22 locally by default and builds and tests ran fine locally