### PR TITLE
chore(deps): update internal version to `0.37.0`, remove temp workaround

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rollup-plugin-typescript2",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rollup-plugin-typescript2",
-      "version": "0.36.1",
+      "version": "0.37.1",
       "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^4.1.2",
@@ -38,7 +38,7 @@
         "rimraf": "3.0.2",
         "rollup": "^2.70.2",
         "rollup-plugin-re": "1.0.7",
-        "rollup-plugin-typescript2": "0.35.0",
+        "rollup-plugin-typescript2": "0.37.0",
         "ts-jest": "^29.1.1",
         "typescript": "^5.1.3"
       },
@@ -9859,16 +9859,17 @@
       }
     },
     "node_modules/rollup-plugin-typescript2": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.35.0.tgz",
-      "integrity": "sha512-szcIO9hPUx3PhQl91u4pfNAH2EKbtrXaES+m163xQVE5O1CC0ea6YZV/5woiDDW3CR9jF2CszPrKN+AFiND0bg==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.37.0.tgz",
+      "integrity": "sha512-S1r/4Ufi13Yg/chPlh4iSHWq2Zs/sIAodW5SKUoCQfy/DEQhkS2XRFEtv+NRq3iBO4WHHfqKtDPOC5lJTYm7OQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@rollup/pluginutils": "^4.1.2",
         "find-cache-dir": "^3.3.2",
         "fs-extra": "^10.0.0",
-        "semver": "^7.3.7",
-        "tslib": "^2.4.0"
+        "semver": "^7.5.4",
+        "tslib": "^2.6.2"
       },
       "peerDependencies": {
         "rollup": ">=1.26.3",
@@ -17911,16 +17912,16 @@
       }
     },
     "rollup-plugin-typescript2": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.35.0.tgz",
-      "integrity": "sha512-szcIO9hPUx3PhQl91u4pfNAH2EKbtrXaES+m163xQVE5O1CC0ea6YZV/5woiDDW3CR9jF2CszPrKN+AFiND0bg==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-typescript2/-/rollup-plugin-typescript2-0.37.0.tgz",
+      "integrity": "sha512-S1r/4Ufi13Yg/chPlh4iSHWq2Zs/sIAodW5SKUoCQfy/DEQhkS2XRFEtv+NRq3iBO4WHHfqKtDPOC5lJTYm7OQ==",
       "dev": true,
       "requires": {
         "@rollup/pluginutils": "^4.1.2",
         "find-cache-dir": "^3.3.2",
         "fs-extra": "^10.0.0",
-        "semver": "^7.3.7",
-        "tslib": "^2.4.0"
+        "semver": "^7.5.4",
+        "tslib": "^2.6.2"
       }
     },
     "rollup-pluginutils": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rollup-plugin-typescript2",
-  "version": "0.37.0",
+  "version": "0.37.1",
   "description": "Seamless integration between Rollup and TypeScript. Now with errors.",
   "main": "dist/rollup-plugin-typescript2.cjs.js",
   "module": "dist/rollup-plugin-typescript2.es.js",
@@ -65,7 +65,7 @@
     "rimraf": "3.0.2",
     "rollup": "^2.70.2",
     "rollup-plugin-re": "1.0.7",
-    "rollup-plugin-typescript2": "0.35.0",
+    "rollup-plugin-typescript2": "0.37.0",
     "ts-jest": "^29.1.1",
     "typescript": "^5.1.3"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,6 @@ import ts from "rollup-plugin-typescript2";
 
 import config from "./rollup.config.base";
 
-config.plugins.push(ts({ verbosity: 2, abortOnError: false, include: ["*.ts{,x}", "**/*.ts{,x}", "**/*.cts", "**/*.mts"] }));
+config.plugins.push(ts({ verbosity: 2, abortOnError: false }));
 
 export default config;


### PR DESCRIPTION


## Summary

<!--
  A short, 1-3 sentence summary of what this PR changes.
  Add "Fixes #<issue-num>" if this resolves a particular issue.
-->

Update internal rpt2 to `0.37.0` so the `picomatch` 2.3.2 compatible workaround can be removed

## Details

<!--
  A **detailed** description of what this PR changes and _why_ it changes that.
-->

- remove the temp workaround for the `picomatch` 2.3.2 compatible pattern in `rollup.config.js` that was added in e158505af3755755fc2c1573cb4f15cde339dce6 / #481 
  - this is now built-in with `0.37.0`, so update to that internally
