### PR TITLE
fix(docs): update `allowJs` pattern for `picomatch` 2.3.2 compat

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This also allows for passing in different `tsconfig` files depending on your bui
 
 ### Some options need additional configuration on plugin side
 
-* `allowJs`: lets TypeScript process JS files as well. If you use it, modify this plugin's `include` option to add `"*.js+(|x)", "**/*.js+(|x)"` (might also want to `exclude` `"**/node_modules/**/*"`, as it can slow down the build significantly).
+* `allowJs`: lets TypeScript process JS files as well. If you use it, modify this plugin's `include` option to add `"*.js{,x}", "**/*.js{,x}"` (might also want to `exclude` `"**/node_modules/**/*"`, as it can slow down the build significantly).
 
 ### Compatibility
 


### PR DESCRIPTION
## Summary

<!--
  A short, 1-3 sentence summary of what this PR changes.
  Add "Fixes #<issue-num>" if this resolves a particular issue.
-->

Change `README` `allowJs` note to use `{,x}` to account for `picomatch` 2.3.2 changes

## Details

<!--
  A **detailed** description of what this PR changes and _why_ it changes that.
-->

- match the `include` on [line 157](https://github.com/ezolenko/rollup-plugin-typescript2/blob/90bd107ea8797a8a0a49e42bc8c9854b68d6a76a/README.md?plain=1#L157)

- I forgot about this line during code review of e158505af3755755fc2c1573cb4f15cde339dce6 / #481, my bad!
