### PR TITLE
fix: normalize cachePlaceholder path for Windows compatibility

### DIFF
--- a/__tests__/integration/no-errors.spec.ts
+++ b/__tests__/integration/no-errors.spec.ts
@@ -86,6 +86,28 @@ test("integration - no errors - no declarations", async () => {
   expect(output.length).toEqual(1); // no other files
 });
 
+test("integration - no errors - cacheRoot with backslashes (Windows path normalization)", async () => {
+  // Simulate Windows-style cacheRoot with backslashes (as returned by findCacheDir() on Windows).
+  // Without normalizePath(), path.relative(cachePlaceholder, fileName) produces a path like
+  // "../../../../src/index.d.ts", which Rollup rejects as an invalid emitted fileName.
+  const windowsStyleCacheRoot = `${testDir}/rpt2-cache-backslash`.replace(/\//g, "\\");
+  const { output } = await genBundle("index.ts", {
+    cacheRoot: windowsStyleCacheRoot,
+    clean: true,
+  });
+
+  // declaration file must have a plain fileName, not a traversal path like "../../../../..."
+  const decFile = findName(output, "index.d.ts");
+  expect(decFile).toBeTruthy();
+  expect(decFile.fileName).not.toMatch(/^\.\./);
+
+  // declaration map sources must be correctly remapped (not pointing into the cache dir)
+  const decMap = findName(output, "index.d.ts.map");
+  const decMapSources = JSON.parse(decMap.source as string).sources;
+  const decRelPath = normalize(path.relative(`${testDir}/dist`, `${fixtureDir}/index.ts`));
+  expect(decMapSources).toEqual([decRelPath]);
+});
+
 test("integration - no errors - allowJs + emitDeclarationOnly", async () => {
   const { output } = await genBundle("some-js-import.js", {
     include: ["**/*.js"],

--- a/src/index.ts
+++ b/src/index.ts
@@ -403,7 +403,7 @@ const typescript: PluginImpl<RPT2Options> = (options) =>
 
 				// don't mutate the entry because generateBundle gets called multiple times
 				let entryText = entry.text
-				const cachePlaceholder = `${pluginOptions.cacheRoot}/placeholder`
+				const cachePlaceholder = normalize(`${pluginOptions.cacheRoot}/placeholder`)
 
 				// modify declaration map sources to correct relative path (only if outputting)
 				if (extension === ".d.ts.map" && (_output?.file || _output?.dir))


### PR DESCRIPTION
## Summary

Fixes #485

On Windows, `findCacheDir()` returns a path with backslashes (e.g. `D:\dev\project\node_modules\.cache\rollup-plugin-typescript2`). Without normalization, `path.relative(cachePlaceholder, fileName)` produces a traversal path like `../../../../src/index.d.ts`, which Rollup rejects as an invalid emitted file name.

## Details

`cachePlaceholder` was constructed as a plain template literal:

```js
const cachePlaceholder = `${pluginOptions.cacheRoot}/placeholder`
```

The fix wraps the value in `normalize()` (already imported as `normalizePath` from `@rollup/pluginutils`, used two lines below):

A regression test was added that explicitly passes a `cacheRoot` with backslashes and verifies that declaration file names are valid and declaration map sources are correctly remapped.
