### PR TITLE
fix(gh): move issue template to `ISSUE_TEMPLATE/` dir

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,3 +1,9 @@
+---
+name: Reproducible Bug Report
+about: If you have a minimal reproduction of a bug within `rollup-plugin-typescript2` itself
+
+---
+
 ## Troubleshooting
 <!--
   Please follow the steps below to ensure that you have troubleshot this problem sufficiently to believe that it is a bug in this plugin.


### PR DESCRIPTION
## Summary

Fix the issue template not working by moving it to the `ISSUE_TEMPLATE/` dir and adding required YAML frontmatter
- as originally reported in https://github.com/ezolenko/rollup-plugin-typescript2/issues/487#issuecomment-4366908366

## Details
- move template and add required YAML frontmatter, [per the issue template docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates#issue-templates)
  - had to figure out this syntax because it's not explicitly documented and the interactive chooser the docs say to use (e.g. https://github.com/agilgur5/rollup-plugin-typescript2/issues/templates/edit) didn't work either...
    - the template chooser doesn't work and throws an error in the console too...:
        ```
        Uncaught TypeError: Cannot read properties of null (reading 'content')
            at HTMLDivElement.capture (template-editor.ts:436:33)
        ```
    - eventually found [a section in the issue forms docs](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/syntax-for-issue-forms#converting-a-markdown-issue-template-to-a-yaml-issue-form-template) that happens to show the syntax for issue template frontmatter
      - but no such example exists in the issue template docs..

- also add `config.yml` to disable blank issues

## Verification
- tested against my own fork with a lot of (pretty frustrating) [trial-and-error](https://github.com/agilgur5/rollup-plugin-typescript2/activity?ref=master)
  - (also had to temporarily enable issues and temporarily disable actions to not waste CI minutes testing this. not an ideal testing format, a branch preview would be very helpful...)

## Historical Context
- the `.github/issue_template.md` single template was apparently silently removed by GitHub:
  - https://github.com/github/docs/commit/21f56d5cea553bfce069b343f19b4039ed5bee69 has some docs removals
    - the [GHE release note](https://github.com/github/docs/blob/21f56d5cea553bfce069b343f19b4039ed5bee69/data/release-notes/enterprise-server/3-18/0.yml#L258) therein explicitly says it is no longer supported (but no announcement for GitHub.com?!?)
  - from our own issues, it appears to have been removed at some point between March 30th ([#485](https://github.com/ezolenko/rollup-plugin-typescript2/issues/485)) and May 3rd 2026 ([#487](https://github.com/ezolenko/rollup-plugin-typescript2/issues/487))
    - it had been working at least since March 26th ([#480](https://github.com/ezolenko/rollup-plugin-typescript2/issues/480))
      - ([#485](https://github.com/ezolenko/rollup-plugin-typescript2/issues/485) was _edited_ to use the template, so unsure if the prompt was seen initially or not)
  - it was reported to GitHub Docs on May 17th (https://github.com/github/docs/issues/44311) and removed from the docs on the 21st via https://github.com/github/docs/commit/9e08905e7e8d6ffff838b9feee587f3c9133486e / https://github.com/github/docs/pull/44312
    - that was apparently originally reported to Nix in https://github.com/NixOS/nixpkgs/commit/556e57ad06c7526d4ecd68da513b6e6ba2664ca8 / https://github.com/NixOS/nixpkgs/pull/521074
    - Note that the word "deprecate" in these instances is incorrect -- it was entirely removed, with no deprecation nor deprecation warning

## Misc Notes
- Note that issue _forms_ are still in beta and still don't support custom markdown/HTML on output, so don't support the "spoiler" `<details>` tag we use to condense various sections
- GitHub has been breaking things [left](https://www.reddit.com/r/ExperiencedDevs/comments/1r0cytn/comment/o4hew0y/) and [right](https://mrshu.github.io/github-statuses/) for many months now...
